### PR TITLE
Cleanup errors in javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,14 @@ subprojects {
 
     java.toolchain.languageVersion = JavaLanguageVersion.of(16)
 
+    tasks.withType(Javadoc).configureEach {
+        options.tags = [
+                'apiNote:a:<em>API Note:</em>',
+                'implSpec:a:<em>Implementation Requirements:</em>',
+                'implNote:a:<em>Implementation Note:</em>'
+        ]
+    }
+
     publishing {
         publications {
             mavenJava(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ subprojects {
                 'implSpec:a:<em>Implementation Requirements:</em>',
                 'implNote:a:<em>Implementation Note:</em>'
         ]
+        options.addStringOption('Xdoclint:all,-missing', '-public')
     }
 
     publishing {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
@@ -40,7 +40,7 @@ import org.apache.logging.log4j.Logger;
  * run, but your own work will be run sequentially.
  * <p>
  * <strong>Use of this class after startup is not possible.</strong> At that
- * point, {@link IThreadListener} should be used instead.
+ * point, {@code ReentrantBlockableEventLoop} should be used instead.
  * <p>
  * Exceptions from tasks will be handled gracefully, causing a mod loading
  * error. Tasks that take egregiously long times to run will be logged.

--- a/fmlcore/src/main/java/net/minecraftforge/fml/DistExecutor.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/DistExecutor.java
@@ -46,7 +46,7 @@ public final class DistExecutor
     private DistExecutor() {}
 
     /**
-     * Run the callable in the supplier only on the specified {@link Side}.
+     * Run the callable in the supplier only on the specified {@link Dist}.
      * This method is NOT sided-safe and special care needs to be taken in code using this method that implicit class
      * loading is not triggered by the Callable.
      *

--- a/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/IExtensionPoint.java
@@ -32,30 +32,30 @@ public interface IExtensionPoint<T extends Record>
      * The predicate tests the version from a remote instance or save for acceptability (Boolean is true for network, false for local save)
      * and returns true if the version is compatible.
      *
-     * <p>Return {@link net.minecraftforge.fml.network.FMLNetworkConstants#IGNORESERVERONLY} in the supplier, if you wish to be ignored
+     * <p>Return {@code net.minecraftforge.fmllegacy.network.FMLNetworkConstants#IGNORESERVERONLY} in the supplier, if you wish to be ignored
      * as a server side only mod.</p>
      * <p>Return true in the predicate for all values of the input string (when network boolean is true) if you are client side,
      * and don't care about matching any potential server version.</p>
      *
      * <p>
      * Examples: A server only mod
-     *
-     * <code><pre>
+     * </p>
+     * <pre>{@code
      *     registerExtensionPoint(DISPLAYTEST, ()->Pair.of(
      *      ()->FMLNetworkConstants.IGNORESERVERONLY, // ignore me, I'm a server only mod
      *      (s,b)->true // i accept anything from the server or the save, if I'm asked
      *     )
-     * </pre></code>
-     * </p>
+     * }</pre>
+     *
      * <p>
      * Examples: A client only mod
-     * <code><pre>
+     * </p>
+     * <pre>{@code
      *     registerExtensionPoint(DISPLAYTEST, ()->Pair.of(
      *      ()->"anything. i don't care", // if i'm actually on the server, this string is sent but i'm a client only mod, so it won't be
      *      (remoteversionstring,networkbool)->networkbool // i accept anything from the server, by returning true if it's asking about the server
      *     )
-     * </pre></code>
-     * </p>
+     * }</pre>
      *
      */
     record DisplayTest(Supplier<String> suppliedVersion, BiPredicate<String, Boolean> remoteVersionTest) implements IExtensionPoint<DisplayTest> {}

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -53,7 +53,7 @@ import static net.minecraftforge.fml.Logging.LOADING;
 /**
  * Loads mods.
  *
- * Dispatch cycle is seen in {@link #loadMods()} and {@link #finishMods()}
+ * Dispatch cycle is seen in {@code #loadMods()} and {@code #finishMods()}
  *
  * Overall sequence for loadMods is:
  * <dl>
@@ -61,28 +61,28 @@ import static net.minecraftforge.fml.Logging.LOADING;
  *     <dd>Constructs the mod instance. Mods can typically setup basic environment such as Event listeners
  *     and Configuration specifications here.</dd>
  *     <dt>Automated dispatches</dt>
- *     <dd>Dispatches automated elements : {@link net.minecraftforge.fml.common.Mod.EventBusSubscriber},
- *     {@link net.minecraftforge.event.RegistryEvent}, {@link net.minecraftforge.common.capabilities.CapabilityInject}
+ *     <dd>Dispatches automated elements : {@code net.minecraftforge.fml.common.Mod.EventBusSubscriber},
+ *     {@code net.minecraftforge.event.RegistryEvent}, {@code net.minecraftforge.common.capabilities.CapabilityInject}
  *     and others</dd>
  *     <dt>CONFIG_LOAD</dt>
  *     <dd>Dispatches ConfigLoadEvent to mods</dd>
  *     <dt>COMMON_SETUP</dt>
- *     <dd>Dispatches {@link net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent} to mods</dd>
+ *     <dd>Dispatches {@code net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent} to mods</dd>
  *     <dt>SIDED_SETUP</dt>
- *     <dd>Dispatches {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent} or
- *     {@link net.minecraftforge.fml.event.lifecycle.FMLDedicatedServerSetupEvent} to mods</dd>
+ *     <dd>Dispatches {@code net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent} or
+ *     {@code net.minecraftforge.fml.event.lifecycle.FMLDedicatedServerSetupEvent} to mods</dd>
  * </dl>
  *
  * Overall sequence for finishMods is:
  * <dl>
  *     <dt>ENQUEUE_IMC</dt>
- *     <dd>Dispatches {@link net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent} to mods,
+ *     <dd>Dispatches {@code net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent} to mods,
  *     for enqueuing {@link InterModComms} messages for other mods to receive subsequently</dd>
  *     <dt>PROCESS_IMC</dt>
- *     <dd>Dispatches {@link net.minecraftforge.fml.event.lifecycle.InterModProcessEvent} to mods,
+ *     <dd>Dispatches {@code net.minecraftforge.fml.event.lifecycle.InterModProcessEvent} to mods,
  *     for processing {@link InterModComms} messages received from other mods prior to this event</dd>
  *     <dt>COMPLETE</dt>
- *     <dd>Dispatches {@link net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent} to mods,
+ *     <dd>Dispatches {@code net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent} to mods,
  *     and completes the mod loading sequence.</dd>
  * </dl>
  */

--- a/fmlcore/src/main/java/net/minecraftforge/fml/OptionalMod.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/OptionalMod.java
@@ -129,7 +129,7 @@ public final class OptionalMod<T>
      * and if the result is non-null, return an {@code Optional} describing the
      * result.  Otherwise return an empty {@code Optional}.
      *
-     * @apiNote This method supports post-processing on optional values, without
+     * API Note: This method supports post-processing on optional values, without
      * the need to explicitly check for a return status.
      *
      * @param <U> The type of the result of the mapping function
@@ -203,7 +203,7 @@ public final class OptionalMod<T>
      * Return the contained mod object, if present, otherwise throw an exception
      * to be created by the provided supplier.
      *
-     * @apiNote A method reference to the exception constructor with an empty
+     * API Note: A method reference to the exception constructor with an empty
      * argument list can be used as the supplier. For example,
      * {@code IllegalStateException::new}
      *

--- a/fmlcore/src/main/java/net/minecraftforge/fml/OptionalMod.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/OptionalMod.java
@@ -129,7 +129,7 @@ public final class OptionalMod<T>
      * and if the result is non-null, return an {@code Optional} describing the
      * result.  Otherwise return an empty {@code Optional}.
      *
-     * API Note: This method supports post-processing on optional values, without
+     * @apiNote This method supports post-processing on optional values, without
      * the need to explicitly check for a return status.
      *
      * @param <U> The type of the result of the mapping function
@@ -203,7 +203,7 @@ public final class OptionalMod<T>
      * Return the contained mod object, if present, otherwise throw an exception
      * to be created by the provided supplier.
      *
-     * API Note: A method reference to the exception constructor with an empty
+     * @apiNote A method reference to the exception constructor with an empty
      * argument list can be used as the supplier. For example,
      * {@code IllegalStateException::new}
      *

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/common/Mod.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/common/Mod.java
@@ -84,7 +84,8 @@ public @interface Mod
         enum Bus {
             /**
              * The main Forge Event Bus.
-             * See {@code MinecraftForge#EVENT_BUS}
+             *
+             * <p>See {@code MinecraftForge#EVENT_BUS}</p>
              */
             FORGE(Bindings.getForgeBus()),
             /**

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/common/Mod.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/common/Mod.java
@@ -33,7 +33,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 /**
  * This defines a Mod to FML.
  * Any class found with this annotation applied will be loaded as a Mod. The instance that is loaded will
- * represent the mod to other Mods in the system. It will be sent various subclasses of {@link ModLifecycleEvent}
+ * represent the mod to other Mods in the system. It will be sent various subclasses of {@code ModLifecycleEvent}
  * at pre-defined times during the loading of the game.
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -51,7 +51,7 @@ public @interface Mod
 
     /**
      * Annotate a class which will be subscribed to an Event Bus at mod construction time.
-     * Defaults to subscribing the current modid to the {@link MinecraftForge#EVENT_BUS}
+     * Defaults to subscribing the current modid to the {@code MinecraftForge#EVENT_BUS}
      * on both sides.
      *
      * @see Bus
@@ -84,7 +84,7 @@ public @interface Mod
         enum Bus {
             /**
              * The main Forge Event Bus.
-             * @see MinecraftForge#EVENT_BUS
+             * See {@code MinecraftForge#EVENT_BUS}
              */
             FORGE(Bindings.getForgeBus()),
             /**

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -41,7 +41,7 @@ import static net.minecraftforge.fml.Logging.LOADING;
 /**
  * Automatic eventbus subscriber - reads {@link net.minecraftforge.fml.common.Mod.EventBusSubscriber}
  * annotations and passes the class instances to the {@link net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus}
- * defined by the annotation. Defaults to {@link MinecraftForge#EVENT_BUS}
+ * defined by the annotation. Defaults to {@code MinecraftForge#EVENT_BUS}
  */
 public class AutomaticEventSubscriber
 {

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/ItemTransform.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/ItemTransform.java.patch
@@ -5,7 +5,7 @@
  import net.minecraftforge.api.distmarker.OnlyIn;
  
 +/**
-+ * @deprecated use {@link net.minecraft.util.math.vector.TransformationMatrix} through {@link net.minecraftforge.client.extensions.IForgeBakedModel#handlePerspective}
++ * @deprecated use {@link com.mojang.math.Transformation} through {@link net.minecraftforge.client.extensions.IForgeBakedModel#handlePerspective}
 + */
  @OnlyIn(Dist.CLIENT)
 +@Deprecated

--- a/patches/minecraft/net/minecraft/server/packs/resources/ResourceManagerReloadListener.java.patch
+++ b/patches/minecraft/net/minecraft/server/packs/resources/ResourceManagerReloadListener.java.patch
@@ -1,17 +1,5 @@
 --- a/net/minecraft/server/packs/resources/ResourceManagerReloadListener.java
 +++ b/net/minecraft/server/packs/resources/ResourceManagerReloadListener.java
-@@ -5,6 +_,11 @@
- import net.minecraft.util.Unit;
- import net.minecraft.util.profiling.ProfilerFiller;
- 
-+/**
-+ * @deprecated Forge: {@link net.minecraftforge.resource.ISelectiveResourceReloadListener}, which selectively allows
-+ * individual resource types being reloaded should rather be used where possible.
-+ */
-+@Deprecated
- public interface ResourceManagerReloadListener extends PreparableReloadListener {
-    default CompletableFuture<Void> m_5540_(PreparableReloadListener.PreparationBarrier p_10752_, ResourceManager p_10753_, ProfilerFiller p_10754_, ProfilerFiller p_10755_, Executor p_10756_, Executor p_10757_) {
-       return p_10752_.m_6769_(Unit.INSTANCE).thenRunAsync(() -> {
 @@ -17,4 +_,9 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/item/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/enchantment/Enchantment.java.patch
@@ -42,7 +42,7 @@
 +   }
 +
 +   /**
-+    * This applies specifically to applying at the enchanting table. The other method {@link #canApply(ItemStack)}
++    * This applies specifically to applying at the enchanting table. The other method {@link #canEnchant(ItemStack)}
 +    * applies for <i>all possible</i> enchantments.
 +    * @param stack
 +    * @return

--- a/patches/minecraft/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -20,7 +20,7 @@
 +    * flower pots from altering vanilla behavior.
 +    *
 +    * @param emptyPot    The empty pot for this pot, or null for self.
-+    * @param block The flower block.
++    * @param p_53528_ The flower block.
 +    * @param properties
 +    */
 +   public FlowerPotBlock(@javax.annotation.Nullable java.util.function.Supplier<FlowerPotBlock> emptyPot, java.util.function.Supplier<? extends Block> p_53528_, BlockBehaviour.Properties properties) {

--- a/patches/minecraft/net/minecraft/world/level/block/LiquidBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/LiquidBlock.java.patch
@@ -17,7 +17,7 @@
 +   }
 +
 +   /**
-+    * @param supplier A fluid supplier such as {@link net.minecraftforge.fmllegacy.RegistryObject<Fluid>}
++    * @param p_54694_ A fluid supplier such as {@link net.minecraftforge.fmllegacy.RegistryObject<net.minecraft.world.level.material.FlowingFluid>}
 +    */
 +   public LiquidBlock(java.util.function.Supplier<? extends FlowingFluid> p_54694_, BlockBehaviour.Properties p_54695_) {
 +      super(p_54695_);

--- a/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -77,7 +77,7 @@
           return this.f_60595_;
        }
  
-+      /** @deprecated use {@link BlockState#getLightValue(IBlockReader, BlockPos)} */
++      /** @deprecated use {@link BlockState#getLightEmission(BlockGetter, BlockPos)} */
 +      @Deprecated
        public int m_60791_() {
           return this.f_60594_;
@@ -92,7 +92,7 @@
           return this.f_60598_;
        }
  
-+      /** @deprecated use {@link BlockState#rotate(IWorld, BlockPos, Rotation)} */
++      /** @deprecated use {@link BlockState#rotate(LevelAccessor, BlockPos, Rotation)} */
 +      @Deprecated
        public BlockState m_60717_(Rotation p_60718_) {
           return this.m_60734_().m_6843_(this.m_7160_(), p_60718_);

--- a/src/fmlcommon/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
+++ b/src/fmlcommon/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
@@ -23,6 +23,8 @@ import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.ModLoadingStage;
 
+import java.util.function.Consumer;
+
 /**
  * This is the first of four commonly called events during mod initialization.
  *
@@ -30,7 +32,7 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * Called after {@link net.minecraftforge.event.RegistryEvent.Register} events have been fired.
  *
- * Either register your listener using {@link net.minecraftforge.fml.AutomaticEventSubscriber} and
+ * Either register your listener using {@link net.minecraftforge.fml.javafmlmod.AutomaticEventSubscriber} and
  * {@link net.minecraftforge.eventbus.api.SubscribeEvent} or
  * {@link net.minecraftforge.eventbus.api.IEventBus#addListener(Consumer)} in your constructor.
  *

--- a/src/fmlcommon/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
+++ b/src/fmlcommon/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
@@ -21,6 +21,8 @@ package net.minecraftforge.fml.event.lifecycle;
 
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fmlserverevents.FMLServerAboutToStartEvent;
+import net.minecraftforge.fmlserverevents.FMLServerStartingEvent;
 
 /**
  * This is the second of four commonly called events during mod core startup.

--- a/src/fmlcommon/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
+++ b/src/fmlcommon/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
@@ -22,6 +22,8 @@ package net.minecraftforge.fml.event.lifecycle;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
 
+import java.util.function.Predicate;
+
 /**
  * This is the fourth of four commonly called events during mod core startup.
  *

--- a/src/main/java/net/minecraftforge/client/ICloudRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/ICloudRenderHandler.java
@@ -24,7 +24,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 
 /**
- * Call {@link net.minecraft.client.world.DimensionRenderInfo#setCloudRenderHandler(ICloudRenderHandler)}, obtained from a {@link ClientWorld} with an implementation of this to override all cloud rendering with your own.
+ * Call {@link net.minecraft.client.renderer.DimensionSpecialEffects#setCloudRenderHandler(ICloudRenderHandler)},
+ * obtained from a {@link ClientLevel} with an implementation of this to override all cloud rendering with your own.
  * This is only responsible for rendering clouds.
  */
 @FunctionalInterface

--- a/src/main/java/net/minecraftforge/client/ISkyRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/ISkyRenderHandler.java
@@ -24,7 +24,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 
 /**
- * Call {@link net.minecraft.client.world.DimensionRenderInfo#setSkyRenderHandler(ISkyRenderHandler)}, obtained from a {@link ClientWorld} with an implementation of this to override all sky rendering with your own.
+ * Call {@link net.minecraft.client.renderer.DimensionSpecialEffects#setSkyRenderHandler(ISkyRenderHandler)}, obtained
+ * from a {@link ClientLevel} with an implementation of this to override all sky rendering with your own.
  * This includes the sun, moon, stars, and sky-coloring.
  */
 @FunctionalInterface

--- a/src/main/java/net/minecraftforge/client/IWeatherParticleRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/IWeatherParticleRenderHandler.java
@@ -24,7 +24,8 @@ import net.minecraft.client.Camera;
 import net.minecraft.client.multiplayer.ClientLevel;
 
 /**
- * Call {@link net.minecraft.client.world.DimensionRenderInfo#setWeatherParticleRenderHandler(net.minecraftforge.client.IWeatherParticleRenderHandler)}, obtained from a {@link ClientWorld} with an implementation of this to override all weather particle rendering with your own.
+ * Call {@link net.minecraft.client.renderer.DimensionSpecialEffects#setWeatherParticleRenderHandler(IWeatherParticleRenderHandler)},
+ * obtained from a {@link ClientLevel} with an implementation of this to override all weather particle rendering with your own.
  * This handles ground particles that can be seen when it's raining (splash/smoke particles).
  * This also includes playing rain sounds.
  */

--- a/src/main/java/net/minecraftforge/client/IWeatherRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/IWeatherRenderHandler.java
@@ -24,7 +24,8 @@ import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.multiplayer.ClientLevel;
 
 /**
- * Call {@link net.minecraft.client.world.DimensionRenderInfo#setWeatherRenderHandler(IWeatherRenderHandler)}, obtained from a {@link ClientWorld} with an implementation of this to override all weather rendering with your own.
+ * Call {@link net.minecraft.client.renderer.DimensionSpecialEffects#setWeatherRenderHandler(IWeatherRenderHandler)},
+ * obtained from a {@link ClientLevel} with an implementation of this to override all weather rendering with your own.
  * This includes rain and snow.
  */
 @FunctionalInterface

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -20,13 +20,15 @@
 package net.minecraftforge.client.event;
 
 import com.google.common.base.Strings;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 /**
  * ClientChatEvent is fired whenever the client is about to send a chat message or command to the server. <br>
  * This event is fired via {@link ForgeEventFactory#onClientSendMessage(String)},
- * which is executed by {@link GuiScreen#sendChatMessage(String, boolean)}<br>
+ * which is executed by {@link net.minecraft.client.gui.screens.Screen#sendMessage(String, boolean)}<br>
  * <br>
  * {@link #message} contains the message that will be sent to the server. This can be changed by mods.<br>
  * {@link #originalMessage} contains the original message that was going to be sent to the server. This cannot be changed by mods.<br>

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.client.event;
 
 import com.google.common.base.Strings;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -28,7 +29,7 @@ import net.minecraftforge.eventbus.api.Event;
 /**
  * ClientChatEvent is fired whenever the client is about to send a chat message or command to the server. <br>
  * This event is fired via {@link ForgeEventFactory#onClientSendMessage(String)},
- * which is executed by {@link net.minecraft.client.gui.screens.Screen#sendMessage(String, boolean)}<br>
+ * which is executed by {@link Screen#sendMessage(String, boolean)}<br>
  * <br>
  * {@link #message} contains the message that will be sent to the server. This can be changed by mods.<br>
  * {@link #originalMessage} contains the original message that was going to be sent to the server. This cannot be changed by mods.<br>

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -64,7 +64,7 @@ public class ClientChatReceivedEvent extends Event
 
     /**
      * The UUID of the player or entity that sent this message, or null if not known.
-     * This will be equal to {@link net.minecraft.util.Util#DUMMY_UUID} for system messages.
+     * This will be equal to {@link net.minecraft.Util#NIL_UUID} for system messages.
      */
     @Nullable
     public UUID getSenderUUID()

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -24,15 +24,15 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.gui.components.Widget;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.screens.Screen;
 
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
+import org.lwjgl.glfw.GLFW;
 
 /**
  * Event classes for GuiScreen events.
@@ -91,10 +91,10 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires just after initializing {@link GuiScreen#mc}, {@link GuiScreen#fontRenderer},
-         * {@link GuiScreen#width}, and {@link GuiScreen#height}.<br/><br/>
+         * This event fires just after initializing the {@link Minecraft}, font renderer, width,
+         * and height fields.<br/><br/>
          *
-         * If canceled the following lines are skipped in {@link GuiScreen#setWorldAndResolution(Minecraft, int, int)}:<br/>
+         * If canceled the following lines are skipped in {@link Screen#init(Minecraft, int, int)}:<br/>
          * {@code this.buttonList.clear();}<br/>
          * {@code this.children.clear();}<br/>
          * {@code this.initGui();}<br/>
@@ -109,7 +109,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires right after {@link GuiScreen#initGui()}.
+         * This event fires right after the {@code init()} method in {@link Screen}.
          * This is a good place to alter a GuiScreen's component layout if desired.
          */
         public static class Post extends InitGuiEvent
@@ -170,8 +170,8 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires just before {@link GuiScreen#render(int, int, float)} is called.
-         * Cancel this event to skip {@link GuiScreen#render(int, int, float)}.
+         * This event fires just before {@link Screen#render(PoseStack, int, int, float)} is called.
+         * Cancel this event to skip the render method.
          */
         @Cancelable
         public static class Pre extends DrawScreenEvent
@@ -183,7 +183,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires just after {@link GuiScreen#render(int, int, float)} is called.
+         * This event fires just after {@link Screen#render(PoseStack, int, int, float)} is called.
          */
         public static class Post extends DrawScreenEvent
         {
@@ -195,7 +195,7 @@ public class GuiScreenEvent extends Event
     }
 
     /**
-     * This event fires at the end of {@link GuiScreen#drawBackground(int)} and before the rest of the Gui draws.
+     * This event fires at the end of {@link Screen#renderBackground(PoseStack, int)} and before the rest of the Gui draws.
      * This allows drawing next to Guis, above the background but below any tooltips.
      */
     public static class BackgroundDrawnEvent extends GuiScreenEvent
@@ -218,8 +218,8 @@ public class GuiScreenEvent extends Event
     }
 
     /**
-     * This event fires in {@link InventoryEffectRenderer#updateActivePotionEffects()}
-     * when potion effects are active and the gui wants to move over.
+     * This event fires in {@link net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen} in the
+     * {@code checkEffectRendering} method when potion effects are active and the gui wants to move over.
      * Cancel this event to prevent the Gui from being moved.
      */
     @Cancelable
@@ -271,7 +271,7 @@ public class GuiScreenEvent extends Event
 
         /**
          * This event fires when a mouse click is detected for a GuiScreen, before it is handled.
-         * Cancel this event to bypass {@link IGuiEventListener#mouseClicked(double, double, int)}.
+         * Cancel this event to bypass {@link GuiEventListener#mouseClicked(double, double, int)}.
          */
         @Cancelable
         public static class Pre extends MouseClickedEvent
@@ -283,7 +283,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires after {@link IGuiEventListener#mouseClicked(double, double, int)} if the click was not already handled.
+         * This event fires after {@link GuiEventListener#mouseClicked(double, double, int)} if the click was not already handled.
          * Cancel this event when you successfully use the mouse click, to prevent other handlers from using the same input.
          */
         @Cancelable
@@ -313,7 +313,7 @@ public class GuiScreenEvent extends Event
 
         /**
          * This event fires when a mouse release is detected for a GuiScreen, before it is handled.
-         * Cancel this event to bypass {@link IGuiEventListener#mouseReleased(double, double, int)}.
+         * Cancel this event to bypass {@link GuiEventListener#mouseReleased(double, double, int)}.
          */
         @Cancelable
         public static class Pre extends MouseReleasedEvent
@@ -325,7 +325,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires after {@link IGuiEventListener#mouseReleased(double, double, int)} if the release was not already handled.
+         * This event fires after {@link GuiEventListener#mouseReleased(double, double, int)} if the release was not already handled.
          * Cancel this event when you successfully use the mouse release, to prevent other handlers from using the same input.
          */
         @Cancelable
@@ -369,7 +369,7 @@ public class GuiScreenEvent extends Event
 
         /**
          * This event fires when a mouse drag is detected for a GuiScreen, before it is handled.
-         * Cancel this event to bypass {@link IGuiEventListener#mouseDragged(double, double, int, double, double)}.
+         * Cancel this event to bypass {@link GuiEventListener#mouseDragged(double, double, int, double, double)}.
          */
         @Cancelable
         public static class Pre extends MouseDragEvent
@@ -381,7 +381,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires after {@link IGuiEventListener#mouseDragged(double, double, int, double, double)} if the drag was not already handled.
+         * This event fires after {@link GuiEventListener#mouseDragged(double, double, int, double, double)} if the drag was not already handled.
          * Cancel this event when you successfully use the mouse drag, to prevent other handlers from using the same input.
          */
         @Cancelable
@@ -411,7 +411,7 @@ public class GuiScreenEvent extends Event
 
         /**
          * This event fires when a mouse scroll is detected for a GuiScreen, before it is handled.
-         * Cancel this event to bypass {@link IGuiEventListener#mouseScrolled(double)}.
+         * Cancel this event to bypass {@link GuiEventListener#mouseScrolled(double, double, double)}.
          */
         @Cancelable
         public static class Pre extends MouseScrollEvent
@@ -423,7 +423,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires after {@link IGuiEventListener#mouseScrolled(double)} if the scroll was not already handled.
+         * This event fires after {@link GuiEventListener#mouseScrolled(double, double, double)} if the scroll was not already handled.
          * Cancel this event when you successfully use the mouse scroll, to prevent other handlers from using the same input.
          */
         @Cancelable
@@ -463,7 +463,7 @@ public class GuiScreenEvent extends Event
 
         /**
          * Platform-specific scan code.
-         * Used for {@link InputMappings#getInputByCode(int, int)}
+         * Used for {@link com.mojang.blaze3d.platform.InputConstants#getKey(int, int)}
          *
          * The scan code is unique for every key, regardless of whether it has a key code.
          * Scan codes are platform-specific but consistent over time, so keys will have different scan codes depending
@@ -498,7 +498,7 @@ public class GuiScreenEvent extends Event
 
         /**
          * This event fires when keyboard input is detected for a GuiScreen, before it is handled.
-         * Cancel this event to bypass {@link IGuiEventListener#keyPressed(int, int, int)}.
+         * Cancel this event to bypass {@link GuiEventListener#keyPressed(int, int, int)}.
          */
         @Cancelable
         public static class Pre extends KeyboardKeyPressedEvent
@@ -510,7 +510,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires after {@link IGuiEventListener#keyPressed(int, int, int)} if the key was not already handled.
+         * This event fires after {@link GuiEventListener#keyPressed(int, int, int)} if the key was not already handled.
          * Cancel this event when you successfully use the keyboard input to prevent other handlers from using the same input.
          */
         @Cancelable
@@ -532,7 +532,7 @@ public class GuiScreenEvent extends Event
 
         /**
          * This event fires when keyboard input is detected for a GuiScreen, before it is handled.
-         * Cancel this event to bypass {@link IGuiEventListener#keyReleased(int, int, int)}.
+         * Cancel this event to bypass {@link GuiEventListener#keyReleased(int, int, int)}.
          */
         @Cancelable
         public static class Pre extends KeyboardKeyReleasedEvent
@@ -544,7 +544,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires after {@link IGuiEventListener#keyReleased(int, int, int)} if the key was not already handled.
+         * This event fires after {@link GuiEventListener#keyReleased(int, int, int)} if the key was not already handled.
          * Cancel this event when you successfully use the keyboard input to prevent other handlers from using the same input.
          */
         @Cancelable
@@ -592,7 +592,7 @@ public class GuiScreenEvent extends Event
 
         /**
          * This event fires when keyboard character input is detected for a GuiScreen, before it is handled.
-         * Cancel this event to bypass {@link IGuiEventListener#charTyped(char, int)}.
+         * Cancel this event to bypass {@link GuiEventListener#charTyped(char, int)}.
          */
         @Cancelable
         public static class Pre extends KeyboardCharTypedEvent
@@ -604,7 +604,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires after {@link IGuiEventListener#charTyped(char, int)} if the character was not already handled.
+         * This event fires after {@link GuiEventListener#charTyped(char, int)} if the character was not already handled.
          * Cancel this event when you successfully use the keyboard input to prevent other handlers from using the same input.
          */
         @Cancelable

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraft.client.gui.screens.Screen;
@@ -218,7 +219,7 @@ public class GuiScreenEvent extends Event
     }
 
     /**
-     * This event fires in {@link net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen} in the
+     * This event fires in {@link EffectRenderingInventoryScreen} in the
      * {@code checkEffectRendering} method when potion effects are active and the gui wants to move over.
      * Cancel this event to prevent the Gui from being moved.
      */

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -110,7 +110,7 @@ public class GuiScreenEvent extends Event
         }
 
         /**
-         * This event fires right after the {@code init()} method in {@link Screen}.
+         * This event fires right after {@code Screen#init()}.
          * This is a good place to alter a GuiScreen's component layout if desired.
          */
         public static class Post extends InitGuiEvent

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -23,6 +23,7 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.world.InteractionHand;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
+import org.lwjgl.glfw.GLFW;
 
 public class InputEvent extends Event
 {
@@ -215,7 +216,7 @@ public class InputEvent extends Event
 
         /**
          * Platform-specific scan code.
-         * Used for {@link InputMappings#getInputByCode(int, int)}
+         * Used for {@link com.mojang.blaze3d.platform.InputConstants#getKey(int, int)}
          *
          * The scan code is unique for every key, regardless of whether it has a key code.
          * Scan codes are platform-specific but consistent over time, so keys will have different scan codes depending

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.client.event;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.world.InteractionHand;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -216,7 +217,7 @@ public class InputEvent extends Event
 
         /**
          * Platform-specific scan code.
-         * Used for {@link com.mojang.blaze3d.platform.InputConstants#getKey(int, int)}
+         * Used for {@link InputConstants#getKey(int, int)}
          *
          * The scan code is unique for every key, regardless of whether it has a key code.
          * Scan codes are platform-specific but consistent over time, so keys will have different scan codes depending

--- a/src/main/java/net/minecraftforge/client/event/InputUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputUpdateEvent.java
@@ -25,7 +25,7 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 
 /**
  * This event is fired after player movement inputs are updated.<br>
- * Handlers can freely manipulate {@link MovementInput} to cancel movement.<br>
+ * Handlers can freely manipulate {@link Input} to cancel movement.<br>
  */
 public class InputUpdateEvent extends PlayerEvent
 {

--- a/src/main/java/net/minecraftforge/client/event/ParticleFactoryRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ParticleFactoryRegisterEvent.java
@@ -19,11 +19,14 @@
 
 package net.minecraftforge.client.event;
 
+import net.minecraft.client.particle.ParticleEngine;
+import net.minecraft.client.particle.ParticleProvider;
+import net.minecraft.core.particles.ParticleType;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
 
 /**
- * Fired when you should call {@link net.minecraft.client.particle.ParticleManager#registerFactory}.
+ * Fired when you should call {@link ParticleEngine#register(ParticleType, ParticleProvider)}.
  * Note that your {@code ParticleType}s should still be registered during the usual registry events, this
  * is only for the factories.
  */

--- a/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.client.event;
 
 import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.eventbus.api.Event;
 
 /**

--- a/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
@@ -148,7 +148,7 @@ public class RenderGameOverlayEvent extends Event
         }
 
         /**
-         * @return The {@link ClientBossInfo} currently being rendered
+         * @return The {@link LerpingBossEvent} currently being rendered
          */
         public LerpingBossEvent getBossInfo()
         {

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -45,7 +45,7 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * This event has a result. {@link HasResult}. <br>
  * ALLOW will force-render name plate/tag, DEFAULT will ignore the hook and continue using the vanilla check
- * & DENY will prevent name plate/tag from rendering<br>
+ * and DENY will prevent name plate/tag from rendering<br>
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -24,6 +24,7 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.network.chat.Component;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.eventbus.api.Event;
 

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  *
  * {@link #screenshotFile} contains the file the screenshot will be/was saved to
  * {@link #image} contains the {@link NativeImage} that will be saved
- * {@link #resultMessage} contains the {@link ITextComponent} to be returned. If {@code null}, the default vanilla message will be used instead
+ * {@link #resultMessage} contains the {@link Component} to be returned. If {@code null}, the default vanilla message will be used instead
  */
 @Cancelable
 public class ScreenshotEvent extends Event

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeRenderChunk.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeRenderChunk.java
@@ -30,7 +30,7 @@ public interface IForgeRenderChunk
      * Extending classes can change the behavior of the cache, allowing to visually change
      * blocks (schematics etc).
      *
-     * @see RegionRenderCache
+     * @see RenderChunkRegion
      * @param world The world to cache.
      * @param from The starting position of the chunk minus one on each axis.
      * @param to The ending position of the chunk plus one on each axis.

--- a/src/main/java/net/minecraftforge/client/model/CompositeModelState.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModelState.java
@@ -24,7 +24,7 @@ import com.mojang.math.Transformation;
 import net.minecraft.client.resources.model.ModelState;
 
 /**
- * An {@link IModelTransform} that combines the transforms from two child {@link IModelTransform}.
+ * An {@link ModelState} that combines the transforms from two child {@link ModelState}.
  */
 public class CompositeModelState implements ModelState
 {

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -53,9 +53,9 @@ import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.UnbakedModel;
 
 /**
- * Forge reimplementation of vanilla {@link ItemModelGenerator}, i.e. builtin/generated models,
+ * Forge reimplementation of vanilla {@link net.minecraft.client.renderer.block.model.ItemModelGenerator}, i.e. builtin/generated models,
  * with the following changes:
- * - Represented as a true {@link IUnbakedModel} so it can be baked as usual instead of using
+ * - Represented as a true {@link UnbakedModel} so it can be baked as usual instead of using
  *   special-case logic like vanilla does.
  * - Various fixes in the baking logic.
  * - Not limited to 4 layers maximum.

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.model.ItemModelGenerator;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
@@ -53,7 +54,7 @@ import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.UnbakedModel;
 
 /**
- * Forge reimplementation of vanilla {@link net.minecraft.client.renderer.block.model.ItemModelGenerator}, i.e. builtin/generated models,
+ * Forge reimplementation of vanilla {@link ItemModelGenerator}, i.e. builtin/generated models,
  * with the following changes:
  * - Represented as a true {@link UnbakedModel} so it can be baked as usual instead of using
  *   special-case logic like vanilla does.

--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -44,7 +44,7 @@ public final class ItemTextureQuadConverter
      * Takes a texture and converts it into BakedQuads.
      * The conversion is done by scanning the texture horizontally and vertically and creating "strips" of the texture.
      * Strips that are of the same size and follow each other are converted into one bigger quad.
-     * </br>
+     * <br/>
      * The resulting list of quads is the texture represented as a list of horizontal OR vertical quads,
      * depending on which creates less quads. If the amount of quads is equal, horizontal is preferred.
      *

--- a/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
@@ -104,7 +104,7 @@ public class ModelLoaderRegistry
 
     /**
      * Makes system aware of your loader.
-     * <b>Must be called from within {@link ModelRegistryEvent}</b>
+     * <b>Must be called from within {@link net.minecraftforge.client.event.ModelRegistryEvent}</b>
      */
     public static void registerLoader(ResourceLocation id, IModelLoader<?> loader)
     {

--- a/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
@@ -35,6 +35,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.resources.ResourceLocation;
 import com.mojang.math.Transformation;
+import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.geometry.IModelGeometry;
 import net.minecraftforge.client.model.geometry.ISimpleModelGeometry;
 import net.minecraftforge.client.model.obj.OBJLoader;
@@ -97,14 +98,14 @@ public class ModelLoaderRegistry
         // Minecraft recreates the ModelBakery on resource reload, but this should only run once during init.
         if (!registryFrozen)
         {
-            net.minecraftforge.fml.ModLoader.get().postEvent(new net.minecraftforge.client.event.ModelRegistryEvent());
+            net.minecraftforge.fml.ModLoader.get().postEvent(new ModelRegistryEvent());
             registryFrozen = true;
         }
     }
 
     /**
      * Makes system aware of your loader.
-     * <b>Must be called from within {@link net.minecraftforge.client.event.ModelRegistryEvent}</b>
+     * <b>Must be called from within {@link ModelRegistryEvent}</b>
      */
     public static void registerLoader(ResourceLocation id, IModelLoader<?> loader)
     {

--- a/src/main/java/net/minecraftforge/client/model/animation/AnimationBlockEntityRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/AnimationBlockEntityRenderer.java
@@ -45,7 +45,7 @@ import net.minecraftforge.common.property.Properties;
 import net.minecraftforge.common.util.LazyOptional;
 
 /**
- * Generic {@link TileGameRenderer} that works with the Forge model system and animations.
+ * Generic {@link BlockEntityRenderer} that works with the Forge model system and animations.
  */
 public class AnimationBlockEntityRenderer<T extends BlockEntity> implements BlockEntityRenderer<T>, IEventHandler<T>
 {

--- a/src/main/java/net/minecraftforge/client/model/data/IDynamicBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/model/data/IDynamicBakedModel.java
@@ -31,7 +31,7 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 
 /**
- * Convenience interface with default implementation of {@link IBakedModel#getQuads(net.minecraft.block.BlockState, net.minecraft.util.Direction, java.util.Random)}.
+ * Convenience interface with default implementation of {@link BakedModel#getQuads(BlockState, Direction, Random, IModelData)}.
  */
 public interface IDynamicBakedModel extends BakedModel
 {

--- a/src/main/java/net/minecraftforge/client/model/generators/ConfiguredModel.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ConfiguredModel.java
@@ -93,7 +93,7 @@ public final class ConfiguredModel {
      * 
      * @throws NullPointerException     if {@code model} is {@code null}
      * @throws IllegalArgumentException if x and/or y rotation are not valid (see
-     *                                  {@link ModelRotation})
+     *                                  {@link BlockModelRotation})
      * @throws IllegalArgumentException if weight is less than or equal to zero
      */
     public ConfiguredModel(ModelFile model, int rotationX, int rotationY, boolean uvLock, int weight) {
@@ -118,7 +118,7 @@ public final class ConfiguredModel {
      * 
      * @throws NullPointerException     if {@code model} is {@code null}
      * @throws IllegalArgumentException if x and/or y rotation are not valid (see
-     *                                  {@link ModelRotation})
+     *                                  {@link BlockModelRotation})
      */
     public ConfiguredModel(ModelFile model, int rotationX, int rotationY, boolean uvLock) {
         this(model, rotationX, rotationY, uvLock, DEFAULT_WEIGHT);
@@ -228,7 +228,7 @@ public final class ConfiguredModel {
          * @param value the x-rotation value
          * @return this builder
          * @throws IllegalArgumentException if {@code value} is not a valid x-rotation
-         *                                  (see {@link ModelRotation})
+         *                                  (see {@link BlockModelRotation})
          */
         public Builder<T> rotationX(int value) {
             checkRotation(value, rotationY);
@@ -242,7 +242,7 @@ public final class ConfiguredModel {
          * @param value the y-rotation value
          * @return this builder
          * @throws IllegalArgumentException if {@code value} is not a valid y-rotation
-         *                                  (see {@link ModelRotation})
+         *                                  (see {@link BlockModelRotation})
          */
         public Builder<T> rotationY(int value) {
             checkRotation(rotationX, value);

--- a/src/main/java/net/minecraftforge/client/model/generators/VariantBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/VariantBlockStateBuilder.java
@@ -137,7 +137,7 @@ public class VariantBlockStateBuilder implements IGeneratedBlockstate {
      * 
      * @param state  The {@link PartialBlockstate partial state} for which to set
      *               the models
-     * @param models A set of models to assign to this state
+     * @param model A set of models to assign to this state
      * @return this builder
      * @throws IllegalArgumentException if {@code state} has already been configured
      * @see #addModels(PartialBlockstate, ConfiguredModel...)

--- a/src/main/java/net/minecraftforge/client/model/geometry/IModelGeometry.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/IModelGeometry.java
@@ -38,7 +38,7 @@ import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.UnbakedModel;
 
 /**
- * General interface for any model that can be baked, superset of vanilla {@link net.minecraft.client.renderer.model.IUnbakedModel}.
+ * General interface for any model that can be baked, superset of vanilla {@link UnbakedModel}.
  * Models can be baked to different vertex formats and with different state.
  */
 public interface IModelGeometry<T extends IModelGeometry<T>>

--- a/src/main/java/net/minecraftforge/client/settings/IKeyConflictContext.java
+++ b/src/main/java/net/minecraftforge/client/settings/IKeyConflictContext.java
@@ -19,18 +19,20 @@
 
 package net.minecraftforge.client.settings;
 
+import net.minecraft.client.KeyMapping;
+
 /**
- * Defines the context that a {@link KeyBinding} is used.
- * Key conflicts occur when a {@link KeyBinding} has the same {@link IKeyConflictContext} and has conflicting modifiers and keyCodes.
+ * Defines the context that a {@link KeyMapping} is used.
+ * Key conflicts occur when a {@link KeyMapping} has the same {@link IKeyConflictContext} and has conflicting modifiers and keyCodes.
  */
 public interface IKeyConflictContext {
     /**
-     * @return true if conditions are met to activate {@link KeyBinding}s with this context
+     * @return true if conditions are met to activate {@link KeyMapping}s with this context
      */
     boolean isActive();
 
     /**
-     * @return true if the other context can have {@link KeyBinding} conflicts with this one.
+     * @return true if the other context can have {@link KeyMapping} conflicts with this one.
      * This will be called on both contexts to check for conflicts.
      */
     boolean conflicts(IKeyConflictContext other);

--- a/src/main/java/net/minecraftforge/client/settings/KeyConflictContext.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyConflictContext.java
@@ -42,7 +42,7 @@ public enum KeyConflictContext implements IKeyConflictContext
     },
 
     /**
-     * Gui key bindings are only used when a {@link GuiScreen} is open.
+     * Gui key bindings are only used when a {@link net.minecraft.client.gui.screens.Screen} is open.
      */
     GUI {
         @Override
@@ -59,7 +59,7 @@ public enum KeyConflictContext implements IKeyConflictContext
     },
 
     /**
-     * In-game key bindings are only used when a {@link GuiScreen} is not open.
+     * In-game key bindings are only used when a {@link net.minecraft.client.gui.screens.Screen} is not open.
      */
     IN_GAME {
         @Override

--- a/src/main/java/net/minecraftforge/client/settings/KeyConflictContext.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyConflictContext.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.client.settings;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 
 public enum KeyConflictContext implements IKeyConflictContext
 {
@@ -42,7 +43,7 @@ public enum KeyConflictContext implements IKeyConflictContext
     },
 
     /**
-     * Gui key bindings are only used when a {@link net.minecraft.client.gui.screens.Screen} is open.
+     * Gui key bindings are only used when a {@link Screen} is open.
      */
     GUI {
         @Override
@@ -59,7 +60,7 @@ public enum KeyConflictContext implements IKeyConflictContext
     },
 
     /**
-     * In-game key bindings are only used when a {@link net.minecraft.client.gui.screens.Screen} is not open.
+     * In-game key bindings are only used when a {@link Screen} is not open.
      */
     IN_GAME {
         @Override

--- a/src/main/java/net/minecraftforge/common/AdvancementLoadFix.java
+++ b/src/main/java/net/minecraftforge/common/AdvancementLoadFix.java
@@ -40,7 +40,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * New implementation of {@link net.minecraft.advancements.PlayerAdvancements#ensureAllVisible()}
+ * New implementation of {@code PlayerAdvancements#ensureAllVisible()}
  */
 public class AdvancementLoadFix {
     private static final Logger LOGGER = LogManager.getLogger();

--- a/src/main/java/net/minecraftforge/common/FarmlandWaterManager.java
+++ b/src/main/java/net/minecraftforge/common/FarmlandWaterManager.java
@@ -47,7 +47,7 @@ public class FarmlandWaterManager
 
     /**
      * Adds a custom ticket.
-     * Use {@link #addAABBTicket(World, AxisAlignedBB)} if you just need a ticket that can water a certain area.
+     * Use {@link #addAABBTicket(Level, AABB)} if you just need a ticket that can water a certain area.
      * <br>
      * If you don't want to water the region anymore, call {@link SimpleTicket#invalidate()}. Also call this
      * when the region this is unloaded (e.g. your TE is unloaded or the block is removed), and validate once it is loaded
@@ -126,7 +126,7 @@ public class FarmlandWaterManager
     }
 
     /**
-     * Tests if a block is in a region that is watered by blocks. This does not check vanilla water, see {@link net.minecraft.block.FarmlandBlock#hasWater(IWorldReader, BlockPos)}
+     * Tests if a block is in a region that is watered by blocks. This does not check vanilla water, see {@code net.minecraft.world.level.block.FarmBlock#isNearWater(LevelReader, BlockPos)}
      * @return true if there is a ticket with an AABB that includes your block
      */
     public static boolean hasBlockWaterTicket(LevelReader world, BlockPos pos)

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -997,7 +997,7 @@ public class ForgeHooks
     }
 
     /**
-     * Hook to fire {@link ItemAttributeModifierEvent}. Modders should use {@link ItemStack#getAttributeModifiers(EquipmentSlotType)} instead.
+     * Hook to fire {@link ItemAttributeModifierEvent}. Modders should use {@link ItemStack#getAttributeModifiers(EquipmentSlot)} instead.
      */
     public static Multimap<Attribute,AttributeModifier> getAttributeModifiers(ItemStack stack, EquipmentSlot equipmentSlot, Multimap<Attribute,AttributeModifier> attributes)
     {

--- a/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
+++ b/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
@@ -55,7 +55,7 @@ public interface IExtensibleEnum
     default void init() {}
 
     /**
-     * Use this instead of {@link IStringSerializable#createEnumCodec(Supplier, Function)} for extensible enums because this not cache the enum values on construction
+     * Use this instead of {@link StringRepresentable#fromEnum(Supplier, Function)} for extensible enums because this not cache the enum values on construction
      */
     static <E extends Enum<E> & StringRepresentable> Codec<E> createCodecForExtensibleEnum(Supplier<E[]> valuesSupplier, Function<? super String, ? extends E> enumValueFromNameFunction) {
         return StringRepresentable.fromStringResolver(Enum::ordinal, (id) -> valuesSupplier.get()[id], enumValueFromNameFunction);

--- a/src/main/java/net/minecraftforge/common/PlantType.java
+++ b/src/main/java/net/minecraftforge/common/PlantType.java
@@ -19,6 +19,11 @@
 
 package net.minecraftforge.common;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.state.BlockState;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
@@ -38,11 +43,11 @@ public final class PlantType
 
     /**
      * Getting a custom {@link PlantType}, or an existing one if it has the same name as that one. Your plant should implement {@link IPlantable}
-     * and return this custom type in {@link IPlantable#getPlantType(IBlockReader, BlockPos)}.
+     * and return this custom type in {@link IPlantable#getPlantType(BlockGetter, BlockPos)}.
      *
      * <p>If your new plant grows on blocks like any one of them above, never create a new {@link PlantType}.
      * This Type is only functioning in
-     * {@link net.minecraft.block.Block#canSustainPlant(BlockState, IBlockReader, BlockPos, Direction, IPlantable)},
+     * {@link net.minecraft.world.level.block.Block#canSustainPlant(BlockState, BlockGetter, BlockPos, Direction, IPlantable)},
      * which you are supposed to override this function in your new block and create a new plant type to grow on that block.
      *
      * This method can be called during parallel loading

--- a/src/main/java/net/minecraftforge/common/PlantType.java
+++ b/src/main/java/net/minecraftforge/common/PlantType.java
@@ -22,6 +22,7 @@ package net.minecraftforge.common;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.Map;
@@ -47,7 +48,7 @@ public final class PlantType
      *
      * <p>If your new plant grows on blocks like any one of them above, never create a new {@link PlantType}.
      * This Type is only functioning in
-     * {@link net.minecraft.world.level.block.Block#canSustainPlant(BlockState, BlockGetter, BlockPos, Direction, IPlantable)},
+     * {@link Block#canSustainPlant(BlockState, BlockGetter, BlockPos, Direction, IPlantable)},
      * which you are supposed to override this function in your new block and create a new plant type to grow on that block.
      *
      * This method can be called during parallel loading

--- a/src/main/java/net/minecraftforge/common/ToolActions.java
+++ b/src/main/java/net/minecraftforge/common/ToolActions.java
@@ -82,7 +82,7 @@ public class ToolActions
     /**
      *  Used during player attack to figure out if a sweep attack should be performed
      *  
-     *  @see {@link IForgeItem#getSweepHitBox}
+     *  @see IForgeItem#getSweepHitBox
      */
     public static final ToolAction SWORD_SWEEP = ToolAction.get("sword_sweep");
 

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityInject.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityInject.java
@@ -28,20 +28,20 @@ import java.lang.annotation.*;
  * of 'Capability'
  *
  * Example:
- * <pre>
- * {@literal @}CapabilityInject(IExampleCapability.class)
+ * <pre>{@code
+ * @CapabilityInject(IExampleCapability.class)
  * private static final Capability<IExampleCapability> TEST_CAP = null;
- * </pre>
+ * }</pre>
  *
  * When placed on a METHOD, the method will be invoked once the
  * capability is registered. This allows you to have a 'enable features'
  * callback. It MUST have one parameter of type 'Capability;
  *
  * Example:
- * <pre>
- * {@literal @}CapabilityInject(IExampleCapability.class)
+ * <pre>{@code
+ * @CapabilityInject(IExampleCapability.class)
  * private static void capRegistered(Capability<IExampleCapability> cap) {}
- * </pre>
+ * }</pre>
  *
  * <b>Warning</b>: Capability injections are run in the thread that the capablity is registered.
  * Due to parallel mod loading, this can potentially be off of the main thread.

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityToken.java
@@ -30,8 +30,7 @@ package net.minecraftforge.common.capabilities;
  * <pre>{@code
  *    public static Capability<IDataHolder> DATA_HOLDER_CAPABILITY
  *    		= CapabilityManager.get(new CapabilityToken<>(){});
- *
- * </pre>
+ * }</pre>
  *
  */
 public abstract class CapabilityToken<T>

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
@@ -33,8 +33,8 @@ public interface ICapabilityProvider
      * Modders are encouraged to cache this value, using the listener capabilities of the Optional to
      * be notified if the requested capability get lost.
      *
-     * @param capability The capability to check
-     * @param facing The Side to check from,
+     * @param cap The capability to check
+     * @param side The Side to check from,
      *   <strong>CAN BE NULL</strong>. Null is defined to represent 'internal' or 'self'
      * @return The requested an optional holding the requested capability.
      */

--- a/src/main/java/net/minecraftforge/common/command/EntitySelectorManager.java
+++ b/src/main/java/net/minecraftforge/common/command/EntitySelectorManager.java
@@ -67,7 +67,7 @@ public class EntitySelectorManager
      * This method is called in {@link EntitySelectorParser#parse} <br>
      *
      * If the REGISTRY does not contain a custom selector for the command being parsed,
-     * this method returns {@code null} and the vanilla logic in {@link EntitySelectorParser#parseSelector} is used.
+     * this method returns {@code null} and the vanilla logic in {@code EntitySelectorParser#parseSelector()} is used.
      */
     public static EntitySelector parseSelector(EntitySelectorParser parser) throws CommandSyntaxException
     {
@@ -88,7 +88,7 @@ public class EntitySelectorManager
     }
 
     /**
-     * This method is called in {@link EntitySelectorParser#fillSelectorSuggestions}
+     * This method is called in {@code EntitySelectorParser#fillSelectorSuggestions(SuggestionsBuilder)}
      */
     public static void fillSelectorSuggestions(SuggestionsBuilder suggestionBuilder)
     {

--- a/src/main/java/net/minecraftforge/common/command/EntitySelectorManager.java
+++ b/src/main/java/net/minecraftforge/common/command/EntitySelectorManager.java
@@ -64,7 +64,7 @@ public class EntitySelectorManager
     }
 
     /**
-     * This method is called in {@link EntitySelectorParser#parse} <br>
+     * This method is called in {@link EntitySelectorParser#parse()} <br>
      *
      * If the REGISTRY does not contain a custom selector for the command being parsed,
      * this method returns {@code null} and the vanilla logic in {@code EntitySelectorParser#parseSelector()} is used.

--- a/src/main/java/net/minecraftforge/common/command/IEntitySelectorType.java
+++ b/src/main/java/net/minecraftforge/common/command/IEntitySelectorType.java
@@ -24,6 +24,8 @@ import net.minecraft.commands.arguments.selector.EntitySelector;
 import net.minecraft.commands.arguments.selector.EntitySelectorParser;
 import net.minecraft.network.chat.Component;
 
+import java.util.function.Predicate;
+
 /**
  * Implementations of this interface can be registered using {@link EntitySelectorManager#register}
  */
@@ -32,13 +34,13 @@ public interface IEntitySelectorType
     /**
      * Returns an {@link EntitySelector} based on the given {@link EntitySelectorParser}. <br>
      *
-     * Use {@link EntitySelectorParser#getReader} to read extra arguments and {@link EntitySelectorParser#addFilter} to add the corresponding filters. <br>
+     * Use {@link EntitySelectorParser#getReader} to read extra arguments and {@link EntitySelectorParser#addPredicate(Predicate)} to add the corresponding filters. <br>
      * If the token being parsed does not match the syntax of this selector, this method should throw an appropriate {@link CommandSyntaxException}.
      */
     EntitySelector build(EntitySelectorParser parser) throws CommandSyntaxException;
 
     /**
-     * Returns an {@link ITextComponent} containing a short description for this selector type.
+     * Returns an {@link Component} containing a short description for this selector type.
      */
     Component getSuggestionTooltip();
 }

--- a/src/main/java/net/minecraftforge/common/crafting/IRecipeContainer.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IRecipeContainer.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.common.crafting;
 
+import net.minecraft.world.inventory.CraftingMenu;
+import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.inventory.ResultContainer;
 import net.minecraft.world.inventory.CraftingContainer;
 
@@ -31,15 +33,15 @@ public interface IRecipeContainer
 {
     /**
      * The crafting result slot of your container, where you take out the crafted item.
-     * The equivalent for {@link ContainerWorkbench} is {@link ContainerWorkbench#craftResult}.
-     * The equivalent for {@link ContainerPlayer} is {@link ContainerPlayer#craftResult}.
+     * The equivalent for {@link CraftingMenu} is {@code CraftingMenu#resultSlots}.
+     * The equivalent for {@link InventoryMenu} is {@code InventoryMenu#resultSlots}.
      */
     ResultContainer getCraftResult();
 
     /**
      * The crafting matrix of your container, where ingredients go for crafting.
-     * The equivalent for {@link ContainerWorkbench} is {@link ContainerWorkbench#craftMatrix}.
-     * The equivalent for {@link ContainerPlayer} is {@link ContainerPlayer#craftMatrix}.
+     * The equivalent for {@link CraftingMenu} is {@code CraftingMenu#craftSlots}.
+     * The equivalent for {@link InventoryMenu} is {@code InventoryMenu#craftSlots}.
      */
     CraftingContainer getCraftMatrix();
 }

--- a/src/main/java/net/minecraftforge/common/data/GlobalLootModifierProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/GlobalLootModifierProvider.java
@@ -103,7 +103,6 @@ public abstract class GlobalLootModifierProvider implements DataProvider
      *
      * @param modifier      The name of the modifier, which will be the file name.
      * @param serializer    The serializer of this modifier.
-     * @param conditions    The loot conditions before {@link LootModifier#doApply} is called.
      */
     public <T extends IGlobalLootModifier> void add(String modifier, GlobalLootModifierSerializer<T> serializer, T instance)
     {

--- a/src/main/java/net/minecraftforge/common/data/GlobalLootModifierProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/GlobalLootModifierProvider.java
@@ -30,6 +30,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Tuple;
 import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
+import net.minecraftforge.common.loot.LootModifier;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -40,7 +41,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Provider for forge's GlobalLootModifier system. See {@link net.minecraftforge.common.loot.LootModifier} and {@link GlobalLootModifierSerializer}.
+ * Provider for forge's GlobalLootModifier system. See {@link LootModifier} and {@link GlobalLootModifierSerializer}.
  *
  * This provider only requires implementing {@link #start()} and calling {@link #add} from it.
  */

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -476,7 +476,7 @@ public interface IForgeBlock
 
     /**
      * Used to determine the state 'viewed' by an entity (see
-     * {@link ActiveRenderInfo#getBlockStateAtEntityViewpoint(World, Entity, float)}).
+     * {@link net.minecraft.client.Camera#getBlockAtCamera()}).
      * Can be used by fluid blocks to determine if the viewpoint is within the fluid or not.
      *
      * @param state     the state
@@ -724,7 +724,7 @@ public interface IForgeBlock
      * Whether redstone dust should visually connect to this block on a given side
      * <p>
      * The default implementation is identical to
-     * {@link RedStoneWireBlock#shouldConnectTo(BlockState, Direction)}
+     * {@code RedStoneWireBlock#shouldConnectTo(BlockState, Direction)}
      *
      * <p>
      * {@link RedStoneWireBlock} updates its visual connection when

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 
+import net.minecraft.client.Camera;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.LivingEntity;
@@ -30,7 +31,9 @@ import net.minecraft.world.entity.SpawnPlacements;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.entity.boss.wither.WitherBoss;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.FishingHook;
 import net.minecraft.world.entity.projectile.WitherSkull;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.block.*;
@@ -69,9 +72,9 @@ public interface IForgeBlock
      * between 0 and 1.
      * <p>
      * Note that entities may reduce slipperiness by a certain factor of their own;
-     * for {@link net.minecraft.world.entity.LivingEntity}, this is {@code .91}.
-     * {@link net.minecraft.world.entity.item.ItemEntity} uses {@code .98}, and
-     * {@link net.minecraft.world.entity.projectile.FishingHook} uses {@code .92}.
+     * for {@link LivingEntity}, this is {@code .91}.
+     * {@link ItemEntity} uses {@code .98}, and
+     * {@link FishingHook} uses {@code .92}.
      *
      * @param state state of the block
      * @param world the world
@@ -476,7 +479,7 @@ public interface IForgeBlock
 
     /**
      * Used to determine the state 'viewed' by an entity (see
-     * {@link net.minecraft.client.Camera#getBlockAtCamera()}).
+     * {@link Camera#getBlockAtCamera()}).
      * Can be used by fluid blocks to determine if the viewpoint is within the fluid or not.
      *
      * @param state     the state

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockEntity.java
@@ -21,6 +21,8 @@ package net.minecraftforge.common.extensions;
 
 import javax.annotation.Nonnull;
 
+import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.Blocks;
@@ -66,11 +68,11 @@ public interface IForgeBlockEntity extends ICapabilitySerializable<CompoundTag>
     default void onDataPacket(net.minecraft.network.Connection net, net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket pkt){ }
 
     /**
-     * Called when the chunk's TE update tag, gotten from {@link #getUpdateTag()}, is received on the client.
+     * Called when the chunk's TE update tag, gotten from {@link BlockEntity#getUpdateTag()}, is received on the client.
      * <p>
-     * Used to handle this tag in a special way. By default this simply calls {@link #readFromNBT(NBTTagCompound)}.
+     * Used to handle this tag in a special way. By default this simply calls {@link BlockEntity#load(CompoundTag)}.
      *
-     * @param tag The {@link NBTTagCompound} sent from {@link #getUpdateTag()}
+     * @param tag The {@link CompoundTag} sent from {@link BlockEntity#getUpdateTag()}
      */
      default void handleUpdateTag(CompoundTag tag)
      {
@@ -78,7 +80,7 @@ public interface IForgeBlockEntity extends ICapabilitySerializable<CompoundTag>
      }
 
     /**
-     * Gets a {@link NBTTagCompound} that can be used to store custom data for this tile entity.
+     * Gets a {@link CompoundTag} that can be used to store custom data for this tile entity.
      * It will be written, and read from disc, so it persists over world saves.
      *
      * @return A compound tag for custom data
@@ -98,16 +100,16 @@ public interface IForgeBlockEntity extends ICapabilitySerializable<CompoundTag>
      }
 
      /**
-      * Sometimes default render bounding box: infinite in scope. Used to control rendering on {@link TileEntitySpecialRenderer}.
+      * Sometimes default render bounding box: infinite in scope. Used to control rendering on {@link BlockEntityWithoutLevelRenderer}.
       */
      public static final AABB INFINITE_EXTENT_AABB = new net.minecraft.world.phys.AABB(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
 
      /**
-      * Return an {@link AxisAlignedBB} that controls the visible scope of a {@link TileEntitySpecialRenderer} associated with this {@link TileEntity}
-      * Defaults to the collision bounding box {@link Block#getCollisionBoundingBoxFromPool(World, int, int, int)} associated with the block
+      * Return an {@link AABB} that controls the visible scope of a {@link BlockEntityWithoutLevelRenderer} associated with this {@link BlockEntity}
+      * Defaults to the collision bounding box {@link BlockState#getCollisionShape(BlockGetter, BlockPos)} associated with the block
       * at this location.
       *
-      * @return an appropriately size {@link AxisAlignedBB} for the {@link TileEntity}
+      * @return an appropriately size {@link AABB} for the {@link BlockEntity}
       */
      default AABB getRenderBoundingBox()
      {
@@ -169,7 +171,7 @@ public interface IForgeBlockEntity extends ICapabilitySerializable<CompoundTag>
 
     /**
      * Allows you to return additional model data.
-     * This data can be used to provide additional functionality in your {@link net.minecraft.client.renderer.model.IBakedModel}
+     * This data can be used to provide additional functionality in your {@link net.minecraft.client.resources.model.BakedModel}
      * You need to schedule a refresh of you model data via {@link #requestModelDataUpdate()} if the result of this function changes.
      * <b>Note that this method may be called on a chunk render thread instead of the main client thread</b>
      * @return Your model data

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockEntity.java
@@ -22,6 +22,7 @@ package net.minecraftforge.common.extensions;
 import javax.annotation.Nonnull;
 
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -171,7 +172,7 @@ public interface IForgeBlockEntity extends ICapabilitySerializable<CompoundTag>
 
     /**
      * Allows you to return additional model data.
-     * This data can be used to provide additional functionality in your {@link net.minecraft.client.resources.model.BakedModel}
+     * This data can be used to provide additional functionality in your {@link BakedModel}
      * You need to schedule a refresh of you model data via {@link #requestModelDataUpdate()} if the result of this function changes.
      * <b>Note that this method may be called on a chunk render thread instead of the main client thread</b>
      * @return Your model data

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -61,9 +61,9 @@ public interface IForgeBlockState
      * between 0 and 1.
      * <p>
      * Note that entities may reduce slipperiness by a certain factor of their own;
-     * for {@link net.minecraft.entity.LivingEntity}, this is {@code .91}.
-     * {@link net.minecraft.entity.item.ItemEntity} uses {@code .98}, and
-     * {@link net.minecraft.entity.projectile.FishingBobberEntity} uses {@code .92}.
+     * for {@link net.minecraft.world.entity.LivingEntity}, this is {@code .91}.
+     * {@link net.minecraft.world.entity.item.ItemEntity} uses {@code .98}, and
+     * {@link net.minecraft.world.entity.projectile.FishingHook} uses {@code .92}.
      *
      * @param world the world
      * @param pos the position in the world
@@ -247,7 +247,7 @@ public interface IForgeBlockState
     }
    /**
     * Allows a block to override the standard vanilla running particles.
-    * This is called from {@link Entity#handleRunningEffect} and is called both,
+    * This is called from {@code Entity#spawnSprintParticle()} and is called both,
     * Client and server side, it's up to the implementor to client check / server check.
     * By default vanilla spawns particles only on the client and the server methods no-op.
     *
@@ -621,7 +621,7 @@ public interface IForgeBlockState
      * @param pos The block position in world
      * @param player The player clicking the block
      * @param stack The stack being used by the player
-     * @param toolType The tool type to be considered when performing the action
+     * @param toolAction The tool type to be considered when performing the action
      * @return The resulting state after the action has been performed
      */
     @Nullable

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -22,12 +22,15 @@ package net.minecraftforge.common.extensions;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
+import net.minecraft.client.Camera;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.SpawnPlacements.Type;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.FishingHook;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
@@ -61,9 +64,9 @@ public interface IForgeBlockState
      * between 0 and 1.
      * <p>
      * Note that entities may reduce slipperiness by a certain factor of their own;
-     * for {@link net.minecraft.world.entity.LivingEntity}, this is {@code .91}.
-     * {@link net.minecraft.world.entity.item.ItemEntity} uses {@code .98}, and
-     * {@link net.minecraft.world.entity.projectile.FishingHook} uses {@code .92}.
+     * for {@link LivingEntity}, this is {@code .91}.
+     * {@link ItemEntity} uses {@code .98}, and
+     * {@link FishingHook} uses {@code .92}.
      *
      * @param world the world
      * @param pos the position in the world
@@ -413,7 +416,7 @@ public interface IForgeBlockState
 
     /**
      * Used to determine the state 'viewed' by an entity (see
-     * {@link net.minecraft.client.Camera#getBlockAtCamera()}).
+     * {@link Camera#getBlockAtCamera()}).
      * Can be used by fluid blocks to determine if the viewpoint is within the fluid or not.
      *
      * @param world     the world

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -21,6 +21,8 @@ package net.minecraftforge.common.extensions;
 
 import java.util.Collection;
 import javax.annotation.Nullable;
+
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MobCategory;
@@ -141,8 +143,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
     /**
      * Gets whether this entity has been added to a world (for tracking). Specifically
      * between the times when an entity is added to a world and the entity being removed
-     * from the world's tracked lists. See {@link World#onEntityAdded(Entity)} and
-     * {@link World#onEntityRemoved(Entity)}.
+     * from the world's tracked lists.
      *
      * @return True if this entity is being tracked by a world
      */
@@ -173,7 +174,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
     /**
      * This is used to specify that your entity has multiple individual parts, such as the Vanilla Ender Dragon.
      *
-     * See {@link net.minecraft.entity.boss.dragon.EnderDragonEntity} for an example implementation.
+     * See {@link net.minecraft.world.entity.boss.enderdragon.EnderDragon} for an example implementation.
      * @return true if this is a multipart entity.
      */
     default boolean isMultipartEntity()
@@ -190,7 +191,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
      *
      * Only used if {@link #isMultipartEntity()} returns true.
      *
-     * See {@link net.minecraft.entity.boss.dragon.EnderDragonEntity} for an example implementation.
+     * See {@link net.minecraft.world.entity.boss.enderdragon.EnderDragon} for an example implementation.
      * @return The child parts of this entity. The value to be returned here should be cached.
      */
     @Nullable

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -22,6 +22,7 @@ package net.minecraftforge.common.extensions;
 import java.util.Collection;
 import javax.annotation.Nullable;
 
+import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
@@ -174,7 +175,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
     /**
      * This is used to specify that your entity has multiple individual parts, such as the Vanilla Ender Dragon.
      *
-     * See {@link net.minecraft.world.entity.boss.enderdragon.EnderDragon} for an example implementation.
+     * See {@link EnderDragon} for an example implementation.
      * @return true if this is a multipart entity.
      */
     default boolean isMultipartEntity()
@@ -191,7 +192,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
      *
      * Only used if {@link #isMultipartEntity()} returns true.
      *
-     * See {@link net.minecraft.world.entity.boss.enderdragon.EnderDragon} for an example implementation.
+     * See {@link EnderDragon} for an example implementation.
      * @return The child parts of this entity. The value to be returned here should be cached.
      */
     @Nullable

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -494,7 +494,7 @@ public interface IForgeItem
 
     /**
      * Return if this itemstack is damaged. Note only called if
-     * {@link #isDamageable()} is true.
+     * {@link ItemStack#isDamageableItem()} is true.
      *
      * @param stack the stack
      * @return if the stack is damaged
@@ -530,7 +530,7 @@ public interface IForgeItem
     }
 
     /**
-     * ItemStack sensitive version of {@link #canHarvestBlock(IBlockState)}
+     * ItemStack sensitive version of {@link Item#isCorrectToolForDrops(BlockState)}
      *
      * @param stack The itemstack used to harvest the block
      * @param state The block trying to harvest
@@ -570,7 +570,7 @@ public interface IForgeItem
      * applies specifically to enchanting an item in the enchanting table and is
      * called when retrieving the list of possible enchantments for an item.
      * Enchantments may additionally (or exclusively) be doing their own checks in
-     * {@link net.minecraft.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)};
+     * {@link net.minecraft.world.item.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)};
      * check the individual implementation for reference. By default this will check
      * if the enchantment type is valid for this item type.
      *
@@ -639,7 +639,7 @@ public interface IForgeItem
      *
      * @param itemStack the ItemStack to check
      * @return the Mod ID for the ItemStack, or null when there is no specially
-     *         associated mod and {@link #getRegistryName()} would return null.
+     *         associated mod and {@link net.minecraftforge.registries.IForgeRegistryEntry#getRegistryName()} would return null.
      */
     @Nullable
     default String getCreatorModId(ItemStack itemStack)
@@ -715,7 +715,7 @@ public interface IForgeItem
     }
 
     /**
-     * Called every tick from {@link EntityHorse#onUpdate()} on the item in the
+     * Called every tick from {@code Horse#playGallopSound(SoundEvent)} on the item in the
      * armor slot.
      *
      * @param stack the armor itemstack
@@ -803,7 +803,7 @@ public interface IForgeItem
     /**
      * Get a bounding box ({@link AABB}) of a sweep attack.
      * 
-     * @param statck the stack held by the player.
+     * @param stack the stack held by the player.
      * @param player the performing the attack the attack.
      * @param target the entity targeted by the attack.
      * @return the bounding box.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -682,7 +682,7 @@ public interface IForgeItem
      * @param shield   The shield in question
      * @param entity   The LivingEntity holding the shield
      * @param attacker The LivingEntity holding the ItemStack
-     * @retrun True if this ItemStack can disable the shield in question.
+     * @return True if this ItemStack can disable the shield in question.
      */
     default boolean canDisableShield(ItemStack stack, ItemStack shield, LivingEntity entity, LivingEntity attacker)
     {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import com.google.common.collect.Multimap;
 
 import net.minecraft.world.item.*;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.level.block.Blocks;
@@ -52,6 +53,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
+import net.minecraftforge.registries.IForgeRegistryEntry;
 
 // TODO review most of the methods in this "patch"
 public interface IForgeItem
@@ -374,7 +376,7 @@ public interface IForgeItem
     /**
      * Override this to set a non-default armor slot for an ItemStack, but <em>do
      * not use this to get the armor slot of said stack; for that, use
-     * {@link net.minecraft.world.entity.LivingEntity#getEquipmentSlotForItem(ItemStack)}..</em>
+     * {@link LivingEntity#getEquipmentSlotForItem(ItemStack)}..</em>
      *
      * @param stack the ItemStack
      * @return the armor slot of the ItemStack, or {@code null} to let the default
@@ -518,7 +520,7 @@ public interface IForgeItem
 
     /**
      * Queries if an item can perform the given action.
-     * See {@link net.minecraftforge.common.ToolActions} for a description of each stock action
+     * See {@link ToolActions} for a description of each stock action
      * @param stack The stack being used
      * @param toolAction The action being queried
      * @return True if the stack can perform the action
@@ -570,7 +572,7 @@ public interface IForgeItem
      * applies specifically to enchanting an item in the enchanting table and is
      * called when retrieving the list of possible enchantments for an item.
      * Enchantments may additionally (or exclusively) be doing their own checks in
-     * {@link net.minecraft.world.item.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)};
+     * {@link Enchantment#canApplyAtEnchantingTable(ItemStack)};
      * check the individual implementation for reference. By default this will check
      * if the enchantment type is valid for this item type.
      *
@@ -578,7 +580,7 @@ public interface IForgeItem
      * @param enchantment the enchantment to be applied
      * @return true if the enchantment can be applied to this item
      */
-    default boolean canApplyAtEnchantingTable(ItemStack stack, net.minecraft.world.item.enchantment.Enchantment enchantment)
+    default boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
     {
         return enchantment.category.canEnchant(stack.getItem());
     }
@@ -639,7 +641,7 @@ public interface IForgeItem
      *
      * @param itemStack the ItemStack to check
      * @return the Mod ID for the ItemStack, or null when there is no specially
-     *         associated mod and {@link net.minecraftforge.registries.IForgeRegistryEntry#getRegistryName()} would return null.
+     *         associated mod and {@link IForgeRegistryEntry#getRegistryName()} would return null.
      */
     @Nullable
     default String getCreatorModId(ItemStack itemStack)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -116,7 +116,6 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     /**
      * Queries if an item can perform the given action.
      * See {@link net.minecraftforge.common.ToolActions} for a description of each stock action
-     * @param stack The stack being used
      * @param toolAction The action being queried
      * @return True if the stack can perform the action
      */
@@ -157,7 +156,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
      * applies specifically to enchanting an item in the enchanting table and is
      * called when retrieving the list of possible enchantments for an item.
      * Enchantments may additionally (or exclusively) be doing their own checks in
-     * {@link net.minecraft.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)};
+     * {@link net.minecraft.world.item.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)};
      * check the individual implementation for reference. By default this will check
      * if the enchantment type is valid for this item type.
      *
@@ -287,7 +286,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     }
 
     /**
-     * Called every tick from {@link HorseEntity#onUpdate()} on the item in the
+     * Called every tick from {@code Horse#playGallopSound(SoundEvent)} on the item in the
      * armor slot.
      *
      * @param world the world the horse is in

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -199,7 +199,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
      * @param shield   The shield in question
      * @param entity   The LivingEntity holding the shield
      * @param attacker The LivingEntity holding the ItemStack
-     * @retrun True if this ItemStack can disable the shield in question.
+     * @return True if this ItemStack can disable the shield in question.
      */
     default boolean canDisableShield(ItemStack shield, LivingEntity entity, LivingEntity attacker)
     {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -115,7 +115,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
 
     /**
      * Queries if an item can perform the given action.
-     * See {@link net.minecraftforge.common.ToolActions} for a description of each stock action
+     * See {@link ToolActions} for a description of each stock action
      * @param toolAction The action being queried
      * @return True if the stack can perform the action
      */
@@ -156,7 +156,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
      * applies specifically to enchanting an item in the enchanting table and is
      * called when retrieving the list of possible enchantments for an item.
      * Enchantments may additionally (or exclusively) be doing their own checks in
-     * {@link net.minecraft.world.item.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)};
+     * {@link Enchantment#canApplyAtEnchantingTable(ItemStack)};
      * check the individual implementation for reference. By default this will check
      * if the enchantment type is valid for this item type.
      *
@@ -181,7 +181,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     /**
      * Override this to set a non-default armor slot for an ItemStack, but <em>do
      * not use this to get the armor slot of said stack; for that, use
-     * {@link net.minecraft.world.entity.LivingEntity#getEquipmentSlotForItem(ItemStack)}.</em>
+     * {@link LivingEntity#getEquipmentSlotForItem(ItemStack)}.</em>
      *
      * @return the armor slot of the ItemStack, or {@code null} to let the default
      *         vanilla logic as per {@code LivingEntity.getSlotForItemStack(stack)}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeMobEffect.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeMobEffect.java
@@ -36,7 +36,7 @@ public interface IForgeMobEffect
     /**
      * Get a fresh list of items that can cure this Potion.
      * All new PotionEffects created from this Potion will call this to initialize the default curative items
-     * @see PotionEffect#getCurativeItems
+     * @see MobEffectInstance#getCurativeItems()
      * @return A list of items that can cure this Potion
      */
     default List<ItemStack> getCurativeItems() {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeMobEffectInstance.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeMobEffectInstance.java
@@ -21,6 +21,7 @@ package net.minecraftforge.common.extensions;
 
 import java.util.List;
 
+import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -31,7 +32,7 @@ public interface IForgeMobEffectInstance
 
     /***
      * Returns a list of curative items for the potion effect
-     * By default, this list is initialized using {@link Potion#getCurativeItems}
+     * By default, this list is initialized using {@link MobEffect#getCurativeItems()}
      *
      * @return The list (ItemStack) of curative items for the potion effect
      */

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeRawTagBuilder.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeRawTagBuilder.java
@@ -52,7 +52,7 @@ public interface IForgeRawTagBuilder
     
     /**
      * Adds a tag entry to the remove list.
-     * @param entry The tag entry to add to the remove list
+     * @param tagEntry The tag entry to add to the remove list
      * @param source The source of the caller for logging purposes (generally a modid)
      * @return The builder for chaining purposes
      */

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeStructureFeature.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeStructureFeature.java
@@ -49,9 +49,9 @@ public interface IForgeStructureFeature
     }
 
     /**
-     * Gets the default list of {@link EntityClassification#MONSTER} spawns for this structure.
+     * Gets the default list of {@link MobCategory#MONSTER} spawns for this structure.
      *
-     * @apiNote Implement this over {@link Structure#getSpawnList()}
+     * @apiNote Implement this over {@link StructureFeature#getSpecialEnemies()}
      *
      * @Deprecated Use {@link IForgeStructureFeature#getDefaultSpawnList(MobCategory)}
      * TODO: Remove in 1.18
@@ -62,9 +62,9 @@ public interface IForgeStructureFeature
     }
 
     /**
-     * Gets the default list of {@link EntityClassification#CREATURE} spawns for this structure.
+     * Gets the default list of {@link MobCategory#CREATURE} spawns for this structure.
      *
-     * @apiNote Implement this over {@link Structure#getCreatureSpawnList()}
+     * @apiNote Implement this over {@link StructureFeature#getSpecialAnimals()}
      *
      * @Deprecated Use {@link IForgeStructureFeature#getDefaultSpawnList(MobCategory)}
      * TODO: Remove in 1.18
@@ -88,7 +88,7 @@ public interface IForgeStructureFeature
     /**
      * Helper method to get the list of entity spawns for this structure for the given classification.
      * @param classification The classification of entities.
-     * @apiNote This method is marked as final in {@link Structure} so as to not be overridden by modders and breaking support for
+     * @apiNote This method is marked as final in {@link StructureFeature} so as to not be overridden by modders and breaking support for
      * {@link net.minecraftforge.event.world.StructureSpawnListGatherEvent}.
      */
     WeightedRandomList<MobSpawnSettings.SpawnerData> getSpawnList(MobCategory classification);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeStructureFeature.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeStructureFeature.java
@@ -53,7 +53,7 @@ public interface IForgeStructureFeature
      *
      * @apiNote Implement this over {@link StructureFeature#getSpecialEnemies()}
      *
-     * @Deprecated Use {@link IForgeStructureFeature#getDefaultSpawnList(MobCategory)}
+     * @deprecated Use {@link IForgeStructureFeature#getDefaultSpawnList(MobCategory)}
      * TODO: Remove in 1.18
      */
     default List<MobSpawnSettings.SpawnerData> getDefaultSpawnList()
@@ -66,7 +66,7 @@ public interface IForgeStructureFeature
      *
      * @apiNote Implement this over {@link StructureFeature#getSpecialAnimals()}
      *
-     * @Deprecated Use {@link IForgeStructureFeature#getDefaultSpawnList(MobCategory)}
+     * @deprecated Use {@link IForgeStructureFeature#getDefaultSpawnList(MobCategory)}
      * TODO: Remove in 1.18
      */
     default List<MobSpawnSettings.SpawnerData> getDefaultCreatureSpawnList()

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
@@ -68,7 +68,7 @@ public interface IForgeTagAppender<T>
     
     /**
      * Adds a registry entry to the tag json's remove list. Callable during datageneration.
-     * @param element The entry to remove
+     * @param entry The entry to remove
      * @return The builder for chaining
      */
     default TagsProvider.TagAppender<T> remove(final T entry)

--- a/src/main/java/net/minecraftforge/common/loot/GlobalLootModifierSerializer.java
+++ b/src/main/java/net/minecraftforge/common/loot/GlobalLootModifierSerializer.java
@@ -59,9 +59,9 @@ public abstract class GlobalLootModifierSerializer<T extends IGlobalLootModifier
      * Most mods will likely not need more than<br/>
      * <code>return new MyModifier(conditionsIn)</code><br/>
      * but any additional properties that are needed will need to be deserialized here.
-     * @param name The resource location (if needed)
-     * @param json The full json object (including ILootConditions)
-     * @param conditionsIn An already deserialized list of ILootConditions
+     * @param location The resource location (if needed)
+     * @param object The full json object (including ILootConditions)
+     * @param ailootcondition An already deserialized list of ILootConditions
      */
     public abstract T read(ResourceLocation location, JsonObject object, LootItemCondition[] ailootcondition);
 

--- a/src/main/java/net/minecraftforge/common/model/animation/IAnimationStateMachine.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/IAnimationStateMachine.java
@@ -48,7 +48,7 @@ public interface IAnimationStateMachine
 
     /**
      * Set to true if the machine should handle special events that come from the clips (they start with '!').
-     * Right now only implemented event is "!transition:<state_name>".
+     * Right now only implemented event is {@literal "!transition:<state_name>"}.
      * Default value is true.
      */
     void shouldHandleSpecialEvents(boolean value);

--- a/src/main/java/net/minecraftforge/common/util/Constants.java
+++ b/src/main/java/net/minecraftforge/common/util/Constants.java
@@ -19,6 +19,18 @@
 
 package net.minecraftforge.common.util;
 
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.TagType;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
+
 /**
  * A class containing constants for magic numbers used in the minecraft codebase.
  * Everything here should be checked each update, and have a comment relating to where to check it.
@@ -26,10 +38,10 @@ package net.minecraftforge.common.util;
 public class Constants
 {
     /**
-     * NBT Tag type IDS, used when storing the nbt to disc, Should align with {@link net.minecraft.nbt.INBT#create}
-     * and {@link net.minecraft.nbt.INBT#getTypeName}
+     * NBT Tag type IDS, used when storing the nbt to disc, Should align with {@link net.minecraft.nbt.TagTypes#getType(int)}
+     * and {@link TagType#getPrettyName()}
      *
-     * Main use is checking tag type in {@link net.minecraft.nbt.CompoundNBT#contains(String, int)}
+     * Main use is checking tag type in {@link net.minecraft.nbt.CompoundTag#contains(String, int)}
      *
      */
     public static class NBT
@@ -51,8 +63,8 @@ public class Constants
     }
 
     /**
-     * The world event IDS, used when calling {@link IWorld#playEvent(int, BlockPos, int)}. <br>
-     * Can be found from {@link net.minecraft.client.renderer.WorldRenderer#playEvent}<br>
+     * The world event IDS, used when calling {@link net.minecraft.world.level.Level#globalLevelEvent(int, BlockPos, int)}. <br>
+     * Can be found from {@link LevelRenderer#globalLevelEvent(int, BlockPos, int)}<br>
      * Some of the events use the {@code data} parameter. If this is the case, an explanation of what {@code data} does is also provided
      */
     public static class WorldEvents {
@@ -113,12 +125,12 @@ public class Constants
         public static final int REDSTONE_TORCH_BURNOUT          = 1502;
         public static final int END_PORTAL_FRAME_FILL           = 1503;
         /**
-         * {@code data} is the {@link Direction#getIndex()} of the direction the smoke is to come out of.
+         * {@code data} is the {@link Direction#get3DDataValue()} of the direction the smoke is to come out of.
          */
         public static final int DISPENSER_SMOKE                 = 2000;
 
         /**
-         * {@code data} is the {@link net.minecraft.block.Block#getStateId state id} of the block broken
+         * {@code data} is the {@link net.minecraft.world.level.block.Block#getId(BlockState)}  state id} of the block broken
          */
         public static final int BREAK_BLOCK_EFFECTS             = 2001;
         /**
@@ -146,21 +158,20 @@ public class Constants
 
     /**
      * The flags used when calling
-     * {@link net.minecraft.world.IWorldWriter#setBlockState(BlockPos, BlockState, int)}<br>
-     * Can be found from {@link World#setBlockState(BlockPos, BlockState, int)},
-     * {@link World#markAndNotifyBlock}, and
-     * {@link WorldRenderer#notifyBlockUpdate}<br>
+     * {@link net.minecraft.world.level.LevelWriter#setBlock(BlockPos, BlockState, int)}<br>
+     * Can be found from {@link Level#setBlock(BlockPos, BlockState, int)} ,
+     * {@link Level#markAndNotifyBlock(BlockPos, LevelChunk, BlockState, BlockState, int, int)}, and
+     * {@link LevelRenderer#blockChanged(BlockGetter, BlockPos, BlockState, BlockState, int)}<br>
      * Flags can be combined with bitwise OR
      */
     public static class BlockFlags {
         /**
-         * Calls
-         * {@link Block#neighborChanged(BlockState, World, BlockPos, Block, BlockPos, boolean)
+         * Calls {@link Block#neighborChanged(BlockState, Level, BlockPos, Block, BlockPos, boolean)
          * neighborChanged} on surrounding blocks (with isMoving as false). Also updates comparator output state.
          */
         public static final int NOTIFY_NEIGHBORS     = (1 << 0);
         /**
-         * Calls {@link World#notifyBlockUpdate(BlockPos, BlockState, BlockState, int)}.<br>
+         * Calls {@link Level#sendBlockUpdated(BlockPos, BlockState, BlockState, int)}.<br>
          * Server-side, this updates all the path-finding navigators.
          */
         public static final int BLOCK_UPDATE         = (1 << 1);
@@ -176,23 +187,22 @@ public class Constants
         /**
          * Causes neighbor updates to be sent to all surrounding blocks (including
          * diagonals). This in turn will call
-         * {@link Block#updateDiagonalNeighbors(BlockState, IWorld, BlockPos, int)
-         * updateDiagonalNeighbors} on both old and new states, and
-         * {@link Block#updateNeighbors(BlockState, IWorld, BlockPos, int)
-         * updateNeighbors} on the new state.
+         * {@link Block#updateIndirectNeighbourShapes(BlockState, LevelAccessor, BlockPos, int, int)}
+         * on both old and new states, and
+         * {@link Block#updateOrDestroy(BlockState, BlockState, LevelAccessor, BlockPos, int, int)} on the new state.
          */
         public static final int UPDATE_NEIGHBORS     = (1 << 4);
 
         /**
          * Prevents neighbor changes from spawning item drops, used by
-         * {@link Block#replaceBlock(BlockState, BlockState, IWorld, BlockPos, int)}.
+         * {@link Block#updateOrDestroy(BlockState, BlockState, LevelAccessor, BlockPos, int)}.
          */
         public static final int NO_NEIGHBOR_DROPS    = (1 << 5);
 
         /**
          * Tell the block being changed that it was moved, rather than removed/replaced,
          * the boolean value is eventually passed to
-         * {@link Block#onReplaced(BlockState, World, BlockPos, BlockState, boolean)}
+         * {@link Block#onRemove(BlockState, Level, BlockPos, BlockState, boolean)}
          * as the last parameter.
          */
         public static final int IS_MOVING            = (1 << 6);

--- a/src/main/java/net/minecraftforge/common/util/Constants.java
+++ b/src/main/java/net/minecraftforge/common/util/Constants.java
@@ -23,10 +23,13 @@ import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.TagType;
+import net.minecraft.nbt.TagTypes;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelWriter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -38,10 +41,10 @@ import net.minecraft.world.level.chunk.LevelChunk;
 public class Constants
 {
     /**
-     * NBT Tag type IDS, used when storing the nbt to disc, Should align with {@link net.minecraft.nbt.TagTypes#getType(int)}
+     * NBT Tag type IDS, used when storing the nbt to disc, Should align with {@link TagTypes#getType(int)}
      * and {@link TagType#getPrettyName()}
      *
-     * Main use is checking tag type in {@link net.minecraft.nbt.CompoundTag#contains(String, int)}
+     * Main use is checking tag type in {@link CompoundTag#contains(String, int)}
      *
      */
     public static class NBT
@@ -63,7 +66,7 @@ public class Constants
     }
 
     /**
-     * The world event IDS, used when calling {@link net.minecraft.world.level.Level#globalLevelEvent(int, BlockPos, int)}. <br>
+     * The world event IDS, used when calling {@link Level#globalLevelEvent(int, BlockPos, int)}. <br>
      * Can be found from {@link LevelRenderer#globalLevelEvent(int, BlockPos, int)}<br>
      * Some of the events use the {@code data} parameter. If this is the case, an explanation of what {@code data} does is also provided
      */
@@ -130,7 +133,7 @@ public class Constants
         public static final int DISPENSER_SMOKE                 = 2000;
 
         /**
-         * {@code data} is the {@link net.minecraft.world.level.block.Block#getId(BlockState)}  state id} of the block broken
+         * {@code data} is the {@link Block#getId(BlockState)}  state id} of the block broken
          */
         public static final int BREAK_BLOCK_EFFECTS             = 2001;
         /**
@@ -158,7 +161,7 @@ public class Constants
 
     /**
      * The flags used when calling
-     * {@link net.minecraft.world.level.LevelWriter#setBlock(BlockPos, BlockState, int)}<br>
+     * {@link LevelWriter#setBlock(BlockPos, BlockState, int)}<br>
      * Can be found from {@link Level#setBlock(BlockPos, BlockState, int)} ,
      * {@link Level#markAndNotifyBlock(BlockPos, LevelChunk, BlockState, BlockState, int, int)}, and
      * {@link LevelRenderer#blockChanged(BlockGetter, BlockPos, BlockState, BlockState, int)}<br>

--- a/src/main/java/net/minecraftforge/common/util/ForgeSoundType.java
+++ b/src/main/java/net/minecraftforge/common/util/ForgeSoundType.java
@@ -19,8 +19,11 @@
 
 package net.minecraftforge.common.util;
 
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraftforge.fmllegacy.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
 
 import javax.annotation.Nonnull;
 import java.util.function.Supplier;

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -36,7 +36,7 @@ import net.minecraft.server.level.ServerLevel;
  * An implementation of this interface can be used to place the entity
  * in a safe location, or generate a return portal, for instance.
  * <p>
- * See the {@link net.minecraft.world.Teleporter} class, which has
+ * See the {@link PortalForcer} class, which has
  * been patched to implement this interface, for a vanilla example.
  */
 public interface ITeleporter
@@ -57,7 +57,7 @@ public interface ITeleporter
      * @param yaw the suggested yaw value to apply
      * @param repositionEntity a function to reposition the entity, which returns the new entity in the new dimension. This is the vanilla implementation of the dimension travel logic. If the supplied boolean is true, it is attempted to spawn a new portal.
      *
-     * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link PlayerEntity}s! Move the player and update its state, see {@link ServerPlayerEntity#changeDimension(net.minecraft.world.server.ServerWorld, ITeleporter)}
+     * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link net.minecraft.world.entity.player.Player}s! Move the player and update its state, see {@link ServerPlayer#changeDimension(ServerLevel, ITeleporter)}
      */
     default Entity placeEntity(Entity entity, ServerLevel currentWorld, ServerLevel destWorld, float yaw, Function<Boolean, Entity> repositionEntity)
     {

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.portal.PortalInfo;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.server.level.ServerPlayer;
@@ -57,7 +58,7 @@ public interface ITeleporter
      * @param yaw the suggested yaw value to apply
      * @param repositionEntity a function to reposition the entity, which returns the new entity in the new dimension. This is the vanilla implementation of the dimension travel logic. If the supplied boolean is true, it is attempted to spawn a new portal.
      *
-     * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link net.minecraft.world.entity.player.Player}s! Move the player and update its state, see {@link ServerPlayer#changeDimension(ServerLevel, ITeleporter)}
+     * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link Player}s! Move the player and update its state, see {@link ServerPlayer#changeDimension(ServerLevel, ITeleporter)}
      */
     default Entity placeEntity(Entity entity, ServerLevel currentWorld, ServerLevel destWorld, float yaw, Function<Boolean, Entity> repositionEntity)
     {

--- a/src/main/java/net/minecraftforge/common/util/LazyOptional.java
+++ b/src/main/java/net/minecraftforge/common/util/LazyOptional.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraftforge.common.capabilities.Capability;
 import org.apache.commons.lang3.mutable.Mutable;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.logging.log4j.Level;
@@ -91,7 +92,7 @@ public class LazyOptional<T>
     /**
      * This method hides an unchecked cast to the inferred type. Only use this if
      * you are sure the type should match. For capabilities, generally
-     * {@link Capability#orEmpty(Capability, LazyOptional)} should be used.
+     * {@link net.minecraftforge.common.capabilities.Capability#orEmpty(Capability, LazyOptional)} should be used.
      * 
      * @return This {@link LazyOptional}, cast to the inferred generic type
      */

--- a/src/main/java/net/minecraftforge/common/util/LazyOptional.java
+++ b/src/main/java/net/minecraftforge/common/util/LazyOptional.java
@@ -92,7 +92,7 @@ public class LazyOptional<T>
     /**
      * This method hides an unchecked cast to the inferred type. Only use this if
      * you are sure the type should match. For capabilities, generally
-     * {@link net.minecraftforge.common.capabilities.Capability#orEmpty(Capability, LazyOptional)} should be used.
+     * {@link Capability#orEmpty(Capability, LazyOptional)} should be used.
      * 
      * @return This {@link LazyOptional}, cast to the inferred generic type
      */

--- a/src/main/java/net/minecraftforge/common/util/NonNullConsumer.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullConsumer.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.common.util;
 
 import javax.annotation.Nonnull;
+import java.util.function.Consumer;
 
 /**
  * Equivalent to {@link Consumer}, except with nonnull contract.

--- a/src/main/java/net/minecraftforge/common/util/NonNullFunction.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullFunction.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.common.util;
 
 import javax.annotation.Nonnull;
+import java.util.function.Function;
 
 /**
  * Equivalent to {@link Function}, except with nonnull contract.

--- a/src/main/java/net/minecraftforge/common/util/NonNullPredicate.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullPredicate.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.common.util;
 
 import javax.annotation.Nonnull;
+import java.util.function.Predicate;
 
 /**
  * Equivalent to {@link Predicate}, except with nonnull contract.

--- a/src/main/java/net/minecraftforge/common/util/NonNullSupplier.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullSupplier.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.common.util;
 
 import javax.annotation.Nonnull;
+import java.util.function.Supplier;
 
 /**
  * Equivalent to {@link Supplier}, except with nonnull contract.

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -24,6 +24,7 @@ import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.server.ServerResources;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.ModLoader;
 
@@ -35,7 +36,7 @@ import java.util.concurrent.Executor;
 import net.minecraft.server.packs.resources.PreparableReloadListener.PreparationBarrier;
 
 /**
- * The main ResourceManager is recreated on each reload, through {@link DataPackRegistries}'s creation.
+ * The main ResourceManager is recreated on each reload, through {@link ServerResources}'s creation.
  *
  * The event is fired on each reload and lets modders add their own ReloadListeners, for server-side resources.
  * The event is fired on the {@link MinecraftForge#EVENT_BUS}

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.event;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
@@ -29,7 +30,7 @@ import javax.annotation.Nullable;
 /**
  * 
  * AnvilUpdateEvent is fired when the inputs (either input stack, or the name) to an anvil are changed. <br> 
- * It is called from {@link RepairContainer#updateRepairOutput}. <br>
+ * It is called from {@link AnvilMenu#createResult()}. <br>
  * If the event is canceled, vanilla behavior will not run, and the output will be set to {@link ItemStack#EMPTY}. <br>
  * If the event is not canceled, but the output is not empty, it will set the output and not run vanilla behavior. <br>
  * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>

--- a/src/main/java/net/minecraftforge/event/CommandEvent.java
+++ b/src/main/java/net/minecraftforge/event/CommandEvent.java
@@ -21,12 +21,14 @@ package net.minecraftforge.event;
 
 import com.mojang.brigadier.ParseResults;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 /**
  * CommandEvent is fired after a command is parsed, but before it is executed.
- * This event is fired during the invocation of {@link Commands#handleCommand(CommandSource, String)}. <br>
+ * This event is fired during the invocation of {@link Commands#performCommand(CommandSourceStack, String)}. <br>
  * <br>
  * {@link #parse} contains the instance of {@link ParseResults} for the parsed command.<br>
  * {@link #exception} begins null, but can be populated with an exception to be thrown within the command.<br>

--- a/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
@@ -20,12 +20,14 @@
 package net.minecraftforge.event;
 
 import net.minecraft.world.Difficulty;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 
 /**
  * DifficultyChangeEvent is fired when difficulty is changing. <br>
  * <br>
- * This event is fired via the {@link ForgeHooks#onDifficultyChange(EnumDifficulty, EnumDifficulty)}.<br>
+ * This event is fired via the {@link ForgeHooks#onDifficultyChange(Difficulty, Difficulty)}.<br>
  * <br>
  * This event does not have a result. {@link HasResult}<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.event;
 
 import com.mojang.brigadier.CommandDispatcher;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 
 
@@ -27,8 +28,8 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 
 /**
- * Commands are rebuilt whenever {@link DataPackRegistries} is recreated.
- * You can use this event to register your commands whenever the {@link net.minecraft.command.Commands} class in constructed.
+ * Commands are rebuilt whenever {@link net.minecraft.server.ServerResources} is recreated.
+ * You can use this event to register your commands whenever the {@link Commands} class in constructed.
  *
  * The event is fired on the {@link MinecraftForge#EVENT_BUS}
  */

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.event;
 
 import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.server.ServerResources;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -28,7 +29,7 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 
 /**
- * Commands are rebuilt whenever {@link net.minecraft.server.ServerResources} is recreated.
+ * Commands are rebuilt whenever {@link ServerResources} is recreated.
  * You can use this event to register your commands whenever the {@link Commands} class in constructed.
  *
  * The event is fired on the {@link MinecraftForge#EVENT_BUS}

--- a/src/main/java/net/minecraftforge/event/RegistryEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegistryEvent.java
@@ -42,7 +42,7 @@ public class RegistryEvent<T extends IForgeRegistryEntry<T>> extends GenericEven
         super(clazz);
     }
     /**
-     * Register new registries when you receive this event, through the {@link RecipeBuilder}
+     * Register new registries when you receive this event, through the {@link net.minecraftforge.registries.RegistryBuilder}
      */
     public static class NewRegistry extends net.minecraftforge.eventbus.api.Event implements IModBusEvent
     {

--- a/src/main/java/net/minecraftforge/event/RegistryEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegistryEvent.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import net.minecraftforge.fml.event.IModBusEvent;
+import net.minecraftforge.registries.RegistryBuilder;
 import org.apache.commons.lang3.Validate;
 
 import com.google.common.collect.ImmutableList;
@@ -42,7 +43,7 @@ public class RegistryEvent<T extends IForgeRegistryEntry<T>> extends GenericEven
         super(clazz);
     }
     /**
-     * Register new registries when you receive this event, through the {@link net.minecraftforge.registries.RegistryBuilder}
+     * Register new registries when you receive this event, through the {@link RegistryBuilder}
      */
     public static class NewRegistry extends net.minecraftforge.eventbus.api.Event implements IModBusEvent
     {

--- a/src/main/java/net/minecraftforge/event/ServerChatEvent.java
+++ b/src/main/java/net/minecraftforge/event/ServerChatEvent.java
@@ -19,14 +19,18 @@
 
 package net.minecraftforge.event;
 
+import net.minecraft.network.protocol.game.ServerboundChatPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * ServerChatEvent is fired whenever a C01PacketChatMessage is processed. <br>
- * This event is fired via {@link ForgeHooks#onServerChatEvent(NetHandlerPlayServer, String, ITextComponent)},
- * which is executed by the {@link NetHandlerPlayServer#processChatMessage(CPacketChatMessage)}<br>
+ * This event is fired via {@link ForgeHooks#onServerChatEvent(ServerGamePacketListenerImpl, String, Component)},
+ * which is executed by the {@link ServerGamePacketListenerImpl#handleChat(ServerboundChatPacket)}<br>
  * <br>
  * {@link #username} contains the username of the player sending the chat message.<br>
  * {@link #message} contains the message being sent.<br>

--- a/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
@@ -26,7 +26,7 @@ import net.minecraftforge.eventbus.api.Event;
 /**
  * Fired on the client when :
  *      {@link TagContainer} has all of its tags synced from the server to the client (just after a client has connected).
- *      The integrated server is about to be created see {@link net.minecraft.client.Minecraft#doLoadLevel}
+ *      The integrated server is about to be created see {@code net.minecraft.client.Minecraft#doLoadLevel}
  * Fired on the server when {@link TagContainer} has read all tags from disk, during initial load and after the reload command is used
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}
  * On the client, this event fires on the Client Thread.

--- a/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
@@ -21,11 +21,11 @@ package net.minecraftforge.event.brewing;
 
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 import javax.annotation.Nonnull;
-
 
 public class PotionBrewEvent extends Event
 {
@@ -60,7 +60,7 @@ public class PotionBrewEvent extends Event
      * PotionBrewEvent.Pre is fired before vanilla brewing takes place.
      * All changes made to the event's array will be made to the TileEntity if the event is canceled.
      * <br>
-     * The event is fired during the {@link BrewingStandTileEntity#brewPotions()} method invocation.<br>
+     * The event is fired during the {@code BrewingStandBlockEntity#doBrew(Level, BlockPos, NonNullList)} method invocation.<br>
      * <br>
      * {@link #stacks} contains the itemstack array from the TileEntityBrewer holding all items in Brewer.<br>
      * <br>
@@ -85,7 +85,7 @@ public class PotionBrewEvent extends Event
     /**
      * PotionBrewEvent.Post is fired when a potion is brewed in the brewing stand.
      * <br>
-     * The event is fired during the {@link BrewingStandTileEntity#brewPotions()} method invocation.<br>
+     * The event is fired during the {@code BrewingStandBlockEntity#doBrew(Level, BlockPos, NonNullList)} method invocation.<br>
      * <br>
      * {@link #stacks} contains the itemstack array from the TileEntityBrewer holding all items in Brewer.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -23,6 +23,8 @@ import net.minecraft.core.SectionPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.Pose;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 /**
@@ -69,7 +71,7 @@ public class EntityEvent extends Event
     /**
      * CanUpdate is fired when an Entity is being created. <br>
      * This event is fired whenever vanilla Minecraft determines that an entity<br>
-     * cannot update in {@link World#updateEntityWithOptionalForce(net.minecraft.entity.Entity, boolean)} <br>
+     * cannot update in {@code World#updateEntityWithOptionalForce(net.minecraft.entity.Entity, boolean)} <br>
      * <br>
      * {@link CanUpdate#canUpdate} contains the boolean value of whether this entity can update.<br>
      * If the modder decides that this Entity can be updated, they may change canUpdate to true, <br>

--- a/src/main/java/net/minecraftforge/event/entity/EntityJoinWorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityJoinWorldEvent.java
@@ -21,12 +21,20 @@ package net.minecraftforge.event.entity;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.ChunkStatus;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * EntityJoinWorldEvent is fired when an Entity joins the world. <br>
  * This event is fired whenever an Entity is added to the world in 
- * {@link World#loadEntities(Collection)}, {@link net.minecraft.world.ServerWorld#loadEntities(Collection)} {@link World#joinEntityInSurroundings(Entity)}, and {@link World#spawnEntity(Entity)}. <br>
- * <strong>Note:</strong> This event may be called before the underlying {@link net.minecraft.world.chunk.Chunk} is promoted to {@link net.minecraft.world.chunk.ChunkStatus#FULL}. You will cause chunk loading deadlocks if you don't delay your world interactions.<br>
+ * {@code Level#loadEntities(Collection)},
+ * {@code net.minecraft.world.ServerWorld#loadEntities(Collection)}
+ * {@code World#joinEntityInSurroundings(Entity)}, and
+ * {@code World#spawnEntity(Entity)}. <br>
+ * <strong>Note:</strong> This event may be called before the underlying {@link LevelChunk} is promoted to {@link ChunkStatus#FULL}.
+ * You will cause chunk loading deadlocks if you don't delay your world interactions.<br>
  * <br>
  * {@link #world} contains the world in which the entity is to join.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/EntityLeaveWorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityLeaveWorldEvent.java
@@ -19,13 +19,17 @@
 
 package net.minecraftforge.event.entity;
 
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * EntityLeaveWorldEvent is fired when an Entity leaves the world. <br>
  * This event is fired whenever an Entity is removed from the world in
- * {@link ClientWorld#removeEntity(Entity)}, {@link ServerWorld#removeEntityComplete(Entity,Boolean)}. <br>
+ * {@link ClientLevel#removeEntity(int, Entity.RemovalReason)}, {@link ServerLevel#removeEntityComplete(Entity, boolean)}. <br>
  * <br>
  * {@link #world} contains the world from which the entity is removed. <br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.event.entity;
 
 import net.minecraft.world.entity.Entity;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event.HasResult;
 
 /**

--- a/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
@@ -28,9 +28,10 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * This event is fired when ever the {@code mobGriefing} game rule is checked.<br>
  * <br>
  * This event has a {@link HasResult result}:
+ * <ul>
  * <li>{@link Result#ALLOW} means this instance of mob griefing is allowed.</li>
  * <li>{@link Result#DEFAULT} means the {@code mobGriefing} game rule is used to determine the behaviour.</li>
- * <li>{@link Result#DENY} means this instance of mob griefing is not allowed.</li><br>
+ * <li>{@link Result#DENY} means this instance of mob griefing is not allowed.</li></ul>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @HasResult

--- a/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
@@ -31,7 +31,8 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * <ul>
  * <li>{@link Result#ALLOW} means this instance of mob griefing is allowed.</li>
  * <li>{@link Result#DEFAULT} means the {@code mobGriefing} game rule is used to determine the behaviour.</li>
- * <li>{@link Result#DENY} means this instance of mob griefing is not allowed.</li></ul>
+ * <li>{@link Result#DENY} means this instance of mob griefing is not allowed.</li>
+ * </ul>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @HasResult

--- a/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.event.entity;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**

--- a/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
@@ -21,11 +21,14 @@ package net.minecraftforge.event.entity;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LightningBolt;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * EntityStruckByLightningEvent is fired when an Entity is about to be struck by lightening.<br>
  * This event is fired whenever an EntityLightningBolt is updated to strike an Entity in
- * {@link EntityLightningBolt#onUpdate()} via {@link ForgeEventFactory#onEntityStruckByLightning(Entity, EntityLightningBolt)}.<br>
+ * {@link LightningBolt#tick()} via {@link ForgeEventFactory#onEntityStruckByLightning(Entity, LightningBolt)}.<br>
  * <br>
  * {@link #lightning} contains the instance of EntityLightningBolt attempting to strike an entity.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -24,6 +24,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.ThrownEnderpearl;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
@@ -64,7 +65,7 @@ public class EntityTeleportEvent extends EntityEvent
 
     /**
      * EntityTeleportEvent.TeleportCommand is fired before a living entity is teleported
-     * from use of {@link net.minecraft.command.impl.TeleportCommand}.
+     * from use of {@link net.minecraft.server.commands.TeleportCommand}.
      * <br>
      * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
      * If the event is not canceled, the entity will be teleported.
@@ -88,7 +89,7 @@ public class EntityTeleportEvent extends EntityEvent
 
     /**
      * EntityTeleportEvent.SpreadPlayersCommand is fired before a living entity is teleported
-     * from use of {@link net.minecraft.command.impl.SpreadPlayersCommand}.
+     * from use of {@link net.minecraft.server.commands.SpreadPlayersCommand}.
      * <br>
      * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
      * If the event is not canceled, the entity will be teleported.

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -26,10 +26,12 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.LogicalSide;
 
 /**
  * EntityTeleportEvent is fired when an event involving any teleportation of an Entity occurs.<br>
- * If a method utilizes this {@link net.minecraftforge.eventbus.api.Event} as its parameter, the method will
+ * If a method utilizes this {@link Event} as its parameter, the method will
  * receive every child event of this class.<br>
  * <br>
  * {@link #getTarget()} contains the target destination.<br>
@@ -67,14 +69,14 @@ public class EntityTeleportEvent extends EntityEvent
      * EntityTeleportEvent.TeleportCommand is fired before a living entity is teleported
      * from use of {@link net.minecraft.server.commands.TeleportCommand}.
      * <br>
-     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * This event is {@link Cancelable}.<br>
      * If the event is not canceled, the entity will be teleported.
      * <br>
      * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      * <br>
-     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
+     * This event is only fired on the {@link LogicalSide#SERVER} side.<br>
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
@@ -91,14 +93,14 @@ public class EntityTeleportEvent extends EntityEvent
      * EntityTeleportEvent.SpreadPlayersCommand is fired before a living entity is teleported
      * from use of {@link net.minecraft.server.commands.SpreadPlayersCommand}.
      * <br>
-     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * This event is {@link Cancelable}.<br>
      * If the event is not canceled, the entity will be teleported.
      * <br>
      * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      * <br>
-     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
+     * This event is only fired on the {@link LogicalSide#SERVER} side.<br>
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
@@ -114,14 +116,14 @@ public class EntityTeleportEvent extends EntityEvent
     /**
      * EntityTeleportEvent.EnderEntity is fired before an Enderman or Shulker randomly teleports.
      * <br>
-     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * This event is {@link Cancelable}.<br>
      * If the event is not canceled, the entity will be teleported.
      * <br>
      * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      * <br>
-     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
+     * This event is only fired on the {@link LogicalSide#SERVER} side.<br>
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
@@ -145,14 +147,14 @@ public class EntityTeleportEvent extends EntityEvent
     /**
      * EntityTeleportEvent.EnderPearl is fired before an Entity is teleported from an EnderPearlEntity.
      * <br>
-     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * This event is {@link Cancelable}.<br>
      * If the event is not canceled, the entity will be teleported.
      * <br>
      * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      * <br>
-     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
+     * This event is only fired on the {@link LogicalSide#SERVER} side.<br>
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
@@ -195,14 +197,14 @@ public class EntityTeleportEvent extends EntityEvent
     /**
      * EntityTeleportEvent.ChorusFruit is fired before a LivingEntity is teleported due to consuming Chorus Fruit.
      * <br>
-     * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * This event is {@link Cancelable}.<br>
      * If the event is not canceled, the entity will be teleported.
      * <br>
      * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      * <br>
-     * This event is only fired on the {@link net.minecraftforge.fml.LogicalSide#SERVER} side.<br>
+     * This event is only fired on the {@link LogicalSide#SERVER} side.<br>
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */

--- a/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
@@ -22,6 +22,7 @@ package net.minecraftforge.event.entity;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**

--- a/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
@@ -22,11 +22,16 @@ package net.minecraftforge.event.entity;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * PlaySoundAtEntityEvent is fired a sound is to be played at an Entity<br>
  * This event is fired whenever a sound is set to be played at an Entity such as in
- * {@link ClientPlayerEntity#playSound(SoundEvent, float, float)} and {@link World#playSound(PlayerEntity, double, double, double, SoundEvent, SoundCategory, float, float)}.<br>
+ * {@link net.minecraft.client.player.LocalPlayer#playSound(SoundEvent, float, float)} and
+ * {@link Level#playSound(Player, double, double, double, SoundEvent, SoundSource, float, float)}.<br>
  * <br>
  * {@link #name} contains the name of the sound to be played at the Entity.<br>
  * {@link #volume} contains the volume at which the sound is to be played originally.<br>

--- a/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.event.entity;
 
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.sounds.SoundEvent;
@@ -30,7 +31,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
 /**
  * PlaySoundAtEntityEvent is fired a sound is to be played at an Entity<br>
  * This event is fired whenever a sound is set to be played at an Entity such as in
- * {@link net.minecraft.client.player.LocalPlayer#playSound(SoundEvent, float, float)} and
+ * {@link LocalPlayer#playSound(SoundEvent, float, float)} and
  * {@link Level#playSound(Player, double, double, double, SoundEvent, SoundSource, float, float)}.<br>
  * <br>
  * {@link #name} contains the name of the sound to be played at the Entity.<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
@@ -21,11 +21,13 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * This event is fired when an {@link EntityAnimal} is tamed. <br>
- * It is fired via {@link ForgeEventFactory#onAnimalTame(EntityAnimal, EntityPlayer)}.
+ * This event is fired when an {@link Animal} is tamed. <br>
+ * It is fired via {@link ForgeEventFactory#onAnimalTame(Animal, Player)}.
  * Forge fires this event for applicable vanilla animals, mods need to fire it themselves.
  * This event is {@link net.minecraftforge.eventbus.api.Cancelable}. If canceled, taming the animal will fail.
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -19,18 +19,21 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import javax.annotation.Nullable;
 
 /**
  * BabyEntitySpawnEvent is fired just before a baby entity is about to be spawned. <br>
  * Parents will have disengaged their relationship. {@link @Cancelable} <br>
- * It is possible to change the child completely by using {@link #setChild(EntityAgeable)} <br>
- * This event is fired from {@link EntityAIMate#spawnBaby()} and {@link EntityAIVillagerMate#giveBirth()} <br>
+ * It is possible to change the child completely by using {@link #setChild(AgeableMob)} <br>
+ * This event is fired from {@link Animal#spawnChildFromBreeding(ServerLevel, Animal)} and
+ * {@link net.minecraft.world.entity.animal.Fox#spawnChildFromBreeding(ServerLevel, Animal)} <br>
  * <br>
  * {@link #parentA} contains the initiating parent entity.<br>
  * {@link #parentB} contains the secondary parent entity.<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 
 /**
  * BabyEntitySpawnEvent is fired just before a baby entity is about to be spawned. <br>
- * Parents will have disengaged their relationship. {@link @Cancelable} <br>
+ * Parents will have disengaged their relationship. {@link Cancelable} <br>
  * It is possible to change the child completely by using {@link #setChild(AgeableMob)} <br>
  * This event is fired from {@link Animal#spawnChildFromBreeding(ServerLevel, Animal)} and
  * {@link net.minecraft.world.entity.animal.Fox#spawnChildFromBreeding(ServerLevel, Animal)} <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -23,6 +23,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.animal.Animal;
+import net.minecraft.world.entity.animal.Fox;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -33,7 +34,7 @@ import javax.annotation.Nullable;
  * Parents will have disengaged their relationship. {@link Cancelable} <br>
  * It is possible to change the child completely by using {@link #setChild(AgeableMob)} <br>
  * This event is fired from {@link Animal#spawnChildFromBreeding(ServerLevel, Animal)} and
- * {@link net.minecraft.world.entity.animal.Fox#spawnChildFromBreeding(ServerLevel, Animal)} <br>
+ * {@link Fox#spawnChildFromBreeding(ServerLevel, Animal)} <br>
  * <br>
  * {@link #parentA} contains the initiating parent entity.<br>
  * {@link #parentB} contains the secondary parent entity.<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
@@ -19,6 +19,9 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
@@ -26,10 +29,10 @@ import net.minecraft.world.entity.LivingEntity;
 /**
  * LivingAttackEvent is fired when a living Entity is attacked. <br>
  * This event is fired whenever an Entity is attacked in
- * {@link EntityLivingBase#attackEntityFrom(DamageSource, float)} and
- * {@link EntityPlayer#attackEntityFrom(DamageSource, float)}. <br>
+ * {@link LivingEntity#hurt(DamageSource, float)} and
+ * {@link Player#hurt(DamageSource, float)}. <br>
  * <br>
- * This event is fired via the {@link ForgeHooks#onLivingAttack(EntityLivingBase, DamageSource, float)}.<br>
+ * This event is fired via the {@link ForgeHooks#onLivingAttack(LivingEntity, DamageSource, float)}.<br>
  * <br>
  * {@link #source} contains the DamageSource of the attack. <br>
  * {@link #amount} contains the amount of damage dealt to the entity. <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
@@ -28,10 +29,10 @@ import net.minecraft.world.entity.LivingEntity;
  * At this point armor, potion and absorption modifiers have already been applied to damage - this is FINAL value.<br>
  * Also note that appropriate resources (like armor durability and absorption extra hearths) have already been consumed.<br>
  * This event is fired whenever an Entity is damaged in
- * {@link EntityLivingBase#damageEntity(DamageSource, float)} and
- * {@link EntityPlayer#damageEntity(DamageSource, float)}.<br>
+ * {@code LivingEntity#actuallyHurt(DamageSource, float)} and
+ * {@code net.minecraft.world.entity.player.Player#actuallyHurt(DamageSource, float)}.<br>
  * <br>
- * This event is fired via the {@link ForgeHooks#onLivingDamage(EntityLivingBase, DamageSource, float)}.<br>
+ * This event is fired via the {@link ForgeHooks#onLivingDamage(LivingEntity, DamageSource, float)}.<br>
  * <br>
  * {@link #source} contains the DamageSource that caused this Entity to be hurt. <br>
  * {@link #amount} contains the final amount of damage that will be dealt to entity. <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
@@ -30,14 +30,14 @@ import net.minecraft.world.entity.LivingEntity;
  * Also note that appropriate resources (like armor durability and absorption extra hearths) have already been consumed.<br>
  * This event is fired whenever an Entity is damaged in
  * {@code LivingEntity#actuallyHurt(DamageSource, float)} and
- * {@code net.minecraft.world.entity.player.Player#actuallyHurt(DamageSource, float)}.<br>
+ * {@code Player#actuallyHurt(DamageSource, float)}.<br>
  * <br>
  * This event is fired via the {@link ForgeHooks#onLivingDamage(LivingEntity, DamageSource, float)}.<br>
  * <br>
  * {@link #source} contains the DamageSource that caused this Entity to be hurt. <br>
  * {@link #amount} contains the final amount of damage that will be dealt to entity. <br>
  * <br>
- * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+ * This event is {@link Cancelable}.<br>
  * If this event is canceled, the Entity is not hurt. Used resources WILL NOT be restored.<br>
  * <br>
  * This event does not have a result. {@link HasResult}<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
@@ -26,11 +28,11 @@ import net.minecraft.world.entity.LivingEntity;
 /**
  * LivingDeathEvent is fired when an Entity dies. <br>
  * This event is fired whenever an Entity dies in
- * {@link EntityLivingBase#onDeath(DamageSource)},
- * {@link EntityPlayer#onDeath(DamageSource)}, and
- * {@link EntityPlayerMP#onDeath(DamageSource)}. <br>
+ * {@link LivingEntity#die(DamageSource)},
+ * {@link net.minecraft.world.entity.player.Player#die(DamageSource)}, and
+ * {@link net.minecraft.server.level.ServerPlayer#die(DamageSource)}. <br>
  * <br>
- * This event is fired via the {@link ForgeHooks#onLivingDeath(EntityLivingBase, DamageSource)}.<br>
+ * This event is fired via the {@link ForgeHooks#onLivingDeath(LivingEntity, DamageSource)}.<br>
  * <br>
  * {@link #source} contains the DamageSource that caused the entity to die. <br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -29,8 +31,8 @@ import net.minecraft.world.entity.LivingEntity;
  * LivingDeathEvent is fired when an Entity dies. <br>
  * This event is fired whenever an Entity dies in
  * {@link LivingEntity#die(DamageSource)},
- * {@link net.minecraft.world.entity.player.Player#die(DamageSource)}, and
- * {@link net.minecraft.server.level.ServerPlayer#die(DamageSource)}. <br>
+ * {@link Player#die(DamageSource)}, and
+ * {@link ServerPlayer#die(DamageSource)}. <br>
  * <br>
  * This event is fired via the {@link ForgeHooks#onLivingDeath(LivingEntity, DamageSource)}.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
@@ -19,13 +19,16 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.core.BlockPos;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * Fired when the ender dragon or wither attempts to destroy a block and when ever a zombie attempts to break a door. Basically a event version of {@link Block#canEntityDestroy(IBlockState, IBlockAccess, BlockPos, Entity)}<br>
+ * Fired when the ender dragon or wither attempts to destroy a block and when ever a zombie attempts to break a door. Basically a event version of {@link net.minecraft.world.level.block.Block#canEntityDestroy(BlockState, BlockGetter, BlockPos, Entity)}<br>
  * <br>
  * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
  * If this event is canceled, the block will not be destroyed.<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.core.BlockPos;
@@ -28,9 +29,9 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * Fired when the ender dragon or wither attempts to destroy a block and when ever a zombie attempts to break a door. Basically a event version of {@link net.minecraft.world.level.block.Block#canEntityDestroy(BlockState, BlockGetter, BlockPos, Entity)}<br>
+ * Fired when the ender dragon or wither attempts to destroy a block and when ever a zombie attempts to break a door. Basically a event version of {@link Block#canEntityDestroy(BlockState, BlockGetter, BlockPos, Entity)}<br>
  * <br>
- * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+ * This event is {@link Cancelable}.<br>
  * If this event is canceled, the block will not be destroyed.<br>
  * <br>
  * This event does not have a result. {@link HasResult}<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
@@ -24,13 +24,16 @@ import java.util.Collection;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * LivingDropsEvent is fired when an Entity's death causes dropped items to appear.<br>
  * This event is fired whenever an Entity dies and drops items in
- * {@link EntityLivingBase#onDeath(DamageSource)}.<br>
+ * {@link LivingEntity#die(DamageSource)}.<br>
  * <br>
- * This event is fired via the {@link ForgeHooks#onLivingDrops(EntityLivingBase, DamageSource, ArrayList, int, boolean)}.<br>
+ * This event is fired via the {@link ForgeHooks#onLivingDrops(LivingEntity, DamageSource, Collection, int, boolean)} .<br>
  * <br>
  * {@link #source} contains the DamageSource that caused the drop to occur.<br>
  * {@link #drops} contains the ArrayList of EntityItems that will be dropped.<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -61,7 +61,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
      *   Drinking Potions/Milk
      *   Guarding with a sword
      *
-     * Cancel the event, or set the duration or <= 0 to prevent it from processing.
+     * Cancel the event, or set the duration or {@literal <=} 0 to prevent it from processing.
      *
      */
     @Cancelable
@@ -76,7 +76,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
     /**
      * Fired every tick that a player is 'using' an item, see {@link Start} for info.
      *
-     * Cancel the event, or set the duration or <= 0 to cause the player to stop using the item.
+     * Cancel the event, or set the duration or {@literal <=} 0 to cause the player to stop using the item.
      *
      */
     @Cancelable

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEquipmentChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEquipmentChangeEvent.java
@@ -22,16 +22,18 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 import javax.annotation.Nonnull;
 
 /**
  * {@link LivingEquipmentChangeEvent} is fired when the Equipment of a Entity changes. <br>
- * This event is fired whenever changes in Equipment are detected in {@link EntityLivingBase#onUpdate()}. <br>
+ * This event is fired whenever changes in Equipment are detected in {@link LivingEntity#tick()}. <br>
  * This also includes entities joining the World, as well as being cloned. <br>
  * This event is fired on server-side only. <br>
  * <br>
- * {@link #slot} contains the affected {@link EntityEquipmentSlot}. <br>
+ * {@link #slot} contains the affected {@link EquipmentSlot}. <br>
  * {@link #from} contains the {@link ItemStack} that was equipped previously. <br>
  * {@link #to} contains the {@link ItemStack} that is equipped now. <br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
@@ -20,6 +20,9 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.animal.horse.Horse;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.event.entity.EntityEvent;
@@ -50,9 +53,9 @@ public class LivingEvent extends EntityEvent
     /**
      * LivingUpdateEvent is fired when an Entity is updated. <br>
      * This event is fired whenever an Entity is updated in
-     * {@link EntityLivingBase#onUpdate()}. <br>
+     * {@link LivingEntity#tick()}. <br>
      * <br>
-     * This event is fired via the {@link ForgeHooks#onLivingUpdate(EntityLivingBase)}.<br>
+     * This event is fired via the {@link ForgeHooks#onLivingUpdate(LivingEntity)}.<br>
      * <br>
      * This event is {@link Cancelable}.<br>
      * If this event is canceled, the Entity does not update.<br>
@@ -70,10 +73,10 @@ public class LivingEvent extends EntityEvent
     /**
      * LivingJumpEvent is fired when an Entity jumps.<br>
      * This event is fired whenever an Entity jumps in
-     * {@link EntityLivingBase#jump()}, {@link EntityMagmaCube#jump()},
-     * and {@link EntityHorse#jump()}.<br>
+     * {@code LivingEntity#jumpFromGround()}, {@code net.minecraft.world.entity.monster.MagmaCube#jumpFromGround()},
+     * and {@code Horse#jumpFromGround()}.<br>
      * <br>
-     * This event is fired via the {@link ForgeHooks#onLivingJump(EntityLivingBase)}.<br>
+     * This event is fired via the {@link ForgeHooks#onLivingJump(LivingEntity)}.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
@@ -20,18 +20,18 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.eventbus.api.Event;
 
 import javax.annotation.Nullable;
 
 /**
  * LivingEvent is fired whenever an event involving Living entities occurs.<br>
- * If a method utilizes this {@link net.minecraftforge.eventbus.api.Event} as its parameter, the method will
+ * If a method utilizes this {@link Event} as its parameter, the method will
  * receive every child event of this class.<br>
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
@@ -73,7 +73,7 @@ public class LivingEvent extends EntityEvent
     /**
      * LivingJumpEvent is fired when an Entity jumps.<br>
      * This event is fired whenever an Entity jumps in
-     * {@code LivingEntity#jumpFromGround()}, {@code net.minecraft.world.entity.monster.MagmaCube#jumpFromGround()},
+     * {@code LivingEntity#jumpFromGround()}, {@code MagmaCube#jumpFromGround()},
      * and {@code Horse#jumpFromGround()}.<br>
      * <br>
      * This event is fired via the {@link ForgeHooks#onLivingJump(LivingEntity)}.<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
@@ -19,15 +19,18 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.LivingEntity;
 
 /**
  * LivingFallEvent is fired when an Entity is set to be falling.<br>
  * This event is fired whenever an Entity is set to fall in
- * {@link EntityLivingBase#fall(float, float)}.<br>
+ * {@link LivingEntity#causeFallDamage(float, float, DamageSource)}.<br>
  * <br>
- * This event is fired via the {@link ForgeHooks#onLivingFall(EntityLivingBase, float, float)}.<br>
+ * This event is fired via the {@link ForgeHooks#onLivingFall(LivingEntity, float, float)}.<br>
  * <br>
  * {@link #distance} contains the distance the Entity is to fall. If this event is canceled, this value is set to 0.0F.
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
@@ -19,14 +19,16 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.LivingEntity;
 
 /**
  * LivingHealEvent is fired when an Entity is set to be healed. <br>
- * This event is fired whenever an Entity is healed in {@link EntityLivingBase#heal(float)}<br>
+ * This event is fired whenever an Entity is healed in {@link LivingEntity#heal(float)}<br>
  * <br>
- * This event is fired via the {@link ForgeEventFactory#onLivingHeal(EntityLivingBase, float)}.<br>
+ * This event is fired via the {@link ForgeEventFactory#onLivingHeal(LivingEntity, float)}.<br>
  * <br>
  * {@link #amount} contains the amount of healing done to the Entity that was healed. <br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
@@ -21,14 +21,17 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * LivingHurtEvent is fired when an Entity is set to be hurt. <br>
  * This event is fired whenever an Entity is hurt in
- * {@link EntityLivingBase#damageEntity(DamageSource, float)} and
- * {@link EntityPlayer#damageEntity(DamageSource, float)}.<br>
+ * {@code LivingEntity#actuallyHurt(DamageSource, float)} and
+ * {@code net.minecraft.world.entity.player.Player#actuallyHurt(DamageSource, float)}.<br>
  * <br>
- * This event is fired via the {@link ForgeHooks#onLivingHurt(EntityLivingBase, DamageSource, float)}.<br>
+ * This event is fired via the {@link ForgeHooks#onLivingHurt(LivingEntity, DamageSource, float)}.<br>
  * <br>
  * {@link #source} contains the DamageSource that caused this Entity to be hurt. <br>
  * {@link #amount} contains the amount of damage dealt to the Entity that was hurt. <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
@@ -29,7 +29,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * LivingHurtEvent is fired when an Entity is set to be hurt. <br>
  * This event is fired whenever an Entity is hurt in
  * {@code LivingEntity#actuallyHurt(DamageSource, float)} and
- * {@code net.minecraft.world.entity.player.Player#actuallyHurt(DamageSource, float)}.<br>
+ * {@code Player#actuallyHurt(DamageSource, float)}.<br>
  * <br>
  * This event is fired via the {@link ForgeHooks#onLivingHurt(LivingEntity, DamageSource, float)}.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
@@ -19,20 +19,23 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * LivingKnockBackEvent is fired when a living entity is about to be knocked back. <br>
  * This event is fired whenever an Entity is knocked back in
- * {@link EntityLivingBase#attackEntityFrom(DamageSource, float)},
- * {@link EntityLivingBase#blockWithShield(EntityLivingBase)},
- * {@link EntityMob#attackEntityAsMob(Entity)} and
- * {@link EntityPlayer#attackTargetEntityWithCurrentItem(Entity)} <br>
+ * {@link LivingEntity#hurt(DamageSource, float)},
+ * {@code LivingEntity#blockUsingShield(LivingEntity)},
+ * {@link net.minecraft.world.entity.Mob#doHurtTarget(Entity)} and
+ * {@link net.minecraft.world.entity.player.Player#attack(Entity)} <br>
  * <br>
- * This event is fired via {@link ForgeHooks#onLivingKnockBack(EntityLivingBase, Entity, float, double, double)}.<br>
+ * This event is fired via {@link ForgeHooks#onLivingKnockBack(LivingEntity, float, double, double)} .<br>
  * <br>
- * {@link #attacker} contains the Entity that caused the knock back. <br>
  * {@link #strength} contains the strength of the knock back. <br>
  * {@link #ratioX} contains the x ratio of the knock back. <br>
  * {@link #ratioZ} contains the z ratio of the knock back. <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
@@ -22,6 +22,8 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -31,8 +33,8 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired whenever an Entity is knocked back in
  * {@link LivingEntity#hurt(DamageSource, float)},
  * {@code LivingEntity#blockUsingShield(LivingEntity)},
- * {@link net.minecraft.world.entity.Mob#doHurtTarget(Entity)} and
- * {@link net.minecraft.world.entity.player.Player#attack(Entity)} <br>
+ * {@link Mob#doHurtTarget(Entity)} and
+ * {@link Player#attack(Entity)} <br>
  * <br>
  * This event is fired via {@link ForgeHooks#onLivingKnockBack(LivingEntity, float, double, double)} .<br>
  * <br>
@@ -40,7 +42,7 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * {@link #ratioX} contains the x ratio of the knock back. <br>
  * {@link #ratioZ} contains the z ratio of the knock back. <br>
  * <br>
- * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+ * This event is {@link Cancelable}.<br>
  * If this event is canceled, the entity is not knocked back.<br>
  * <br>
  * This event does not have a result. {@link HasResult}<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSetAttackTargetEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSetAttackTargetEvent.java
@@ -20,14 +20,16 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
 
 /**
  * LivingSetAttackTargetEvent is fired when an Entity sets a target to attack.<br>
  * This event is fired whenever an Entity sets a target to attack in
- * {@link EntityLiving#setAttackTarget(EntityLivingBase)} and
- * {@link EntityLivingBase#setRevengeTarget(EntityLivingBase)}.<br>
+ * {@link Mob#setTarget(LivingEntity)}.<br>
  * <br>
- * This event is fired via the {@link ForgeHooks#onLivingSetAttackTarget(EntityLivingBase, EntityLivingBase)}.<br>
+ * This event is fired via the {@link ForgeHooks#onLivingSetAttackTarget(LivingEntity, LivingEntity)}.<br>
  * <br>
  * {@link #target} contains the newly targeted Entity.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -20,17 +20,21 @@
 package net.minecraftforge.event.entity.living;
 
 import javax.annotation.Nullable;
+
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.BaseSpawner;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.Level;
 
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Event.HasResult;
 
 /**
  * LivingSpawnEvent is fired for any events associated with Living Entities spawn status. <br>
- * If a method utilizes this {@link Event} as its parameter, the method will
+ * If a method utilizes this event as its parameter, the method will
  * receive every child event of this class.<br>
  * <br>
  * {@link #world} contains the world in which this living Entity is being spawned.<br>
@@ -114,7 +118,7 @@ public class LivingSpawnEvent extends LivingEvent
      * SpecialSpawn is fired when an Entity is to be spawned.<br>
      * This allows you to do special inializers in the new entity.<br>
      * <br>
-     * This event is fired via the {@link ForgeEventFactory#doSpecialSpawn(EntityLiving, World, float, float, float)}.<br>
+     * This event is fired via the {@link ForgeEventFactory#doSpecialSpawn(Mob, Level, float, float, float, BaseSpawner, MobSpawnType)}.<br>
      * <br>
      * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
      * If this event is canceled, the Entity is not spawned.<br>
@@ -160,7 +164,7 @@ public class LivingSpawnEvent extends LivingEvent
      * This is fired every tick for every despawnable entity. Be efficient in your handlers.
      *
      * Note: this is not fired <em>if</em> the mob is definitely going to otherwise despawn. It is fired to check if
-     * the mob can be allowed to despawn. See {@link EntityLiving#despawnEntity}
+     * the mob can be allowed to despawn. See {@link LivingEntity#checkDespawn()}
      *
      * @author cpw
      *

--- a/src/main/java/net/minecraftforge/event/entity/living/PotionColorCalculationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/PotionColorCalculationEvent.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.Collections;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * Fires after Potion Color Calculation.

--- a/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
@@ -19,19 +19,18 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.effect.MobEffect;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraftforge.eventbus.api.Cancelable;
-
-import net.minecraftforge.eventbus.api.Event.HasResult;
-
 /**
- * This Event and its subevents gets fired from  {@link EntityLivingBase} on the  {@link MinecraftForge#EVENT_BUS}.<br>
+ * This Event and its subevents gets fired from  {@link LivingEntity} on the  {@link MinecraftForge#EVENT_BUS}.<br>
  */
 public class PotionEvent extends LivingEvent
 {
@@ -83,7 +82,7 @@ public class PotionEvent extends LivingEvent
         }
         
         /**
-         * @return the PotionEffect. In the remove event this can be null if the Entity does not have a {@link Potion} of the right type active.
+         * @return the PotionEffect. In the remove event this can be null if the Entity does not have a {@link MobEffect} of the right type active.
          */
         @Override
         @Nullable

--- a/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
@@ -22,13 +22,13 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.monster.Zombie;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.EntityEvent;
-
-import net.minecraftforge.eventbus.api.Event.HasResult;
 
 /**
  * ZombieEvent is fired whenever a zombie is spawned for aid.
- * If a method utilizes this {@link Event} as its parameter, the method will
+ * If a method utilizes this event as its parameter, the method will
  * receive every child event of this class.
  * 
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
@@ -48,9 +48,9 @@ public class ZombieEvent extends EntityEvent {
     /**
      * SummonAidEvent is fired when a Zombie Entity is summoned.
      * This event is fired whenever a Zombie Entity is summoned in 
-     * {@link EntityZombie#attackEntityFrom(DamageSource, float)}.
+     * {@code Zombie#actuallyHurt(DamageSource, float)}.
      * 
-     * This event is fired via the {@link ForgeEventFactory#fireZombieSummonAid(EntityZombie, World, int, int, int, EntityLivingBase, double)}.
+     * This event is fired via the {@link ForgeEventFactory#fireZombieSummonAid(Zombie, Level, int, int, int, LivingEntity, double)}.
      * 
      * {@link #customSummonedAid} remains null, but can be populated with a custom EntityZombie which will be spawned.
      * {@link #world} contains the world that this summoning is occurring in.

--- a/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.event.entity.player;
 
 import net.minecraft.advancements.Advancement;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.MinecraftForge;
 
 /**
  * This event is fired when a player gets an advancement.

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.event.entity.player;
 
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -29,7 +31,7 @@ import javax.annotation.Nonnull;
 /**
  * ArrowLooseEvent is fired when a player stops using a bow.<br>
  * This event is fired whenever a player stops using a bow in
- * {@link ItemBow#onPlayerStoppedUsing(ItemStack, World, EntityLivingBase, int)}.<br>
+ * {@link net.minecraft.world.item.BowItem#releaseUsing(ItemStack, Level, LivingEntity, int)}.<br>
  * <br>
  * {@link #bow} contains the ItemBow ItemStack that was used in this event.<br>
  * {@link #charge} contains the value for how much the player had charged before stopping the shot.<br>

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.BowItem;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.player.Player;
@@ -31,12 +32,12 @@ import javax.annotation.Nonnull;
 /**
  * ArrowLooseEvent is fired when a player stops using a bow.<br>
  * This event is fired whenever a player stops using a bow in
- * {@link net.minecraft.world.item.BowItem#releaseUsing(ItemStack, Level, LivingEntity, int)}.<br>
+ * {@link BowItem#releaseUsing(ItemStack, Level, LivingEntity, int)}.<br>
  * <br>
  * {@link #bow} contains the ItemBow ItemStack that was used in this event.<br>
  * {@link #charge} contains the value for how much the player had charged before stopping the shot.<br>
  * <br>
- * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+ * This event is {@link Cancelable}.<br>
  * If this event is canceled, the player does not stop using the bow.<br>
  * <br>
  * This event does not have a result. {@link HasResult}<br>

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
@@ -20,17 +20,19 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BowItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
 
 import javax.annotation.Nonnull;
 
 /**
  * ArrowNockEvent is fired when a player begins using a bow.<br>
  * This event is fired whenever a player begins using a bow in
- * {@link ItemBow#onItemRightClick(World, EntityPlayer, EnumHand)}.<br>
+ * {@link BowItem#use(Level, Player, InteractionHand)}.<br>
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/

--- a/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.event.entity.player;
 
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -26,7 +27,7 @@ import net.minecraft.world.entity.player.Player;
 /**
  * AttackEntityEvent is fired when a player attacks an Entity.<br>
  * This event is fired whenever a player attacks an Entity in
- * {@link EntityPlayer#attackTargetEntityWithCurrentItem(Entity)}.<br>
+ * {@link Player#attack(Entity)}.<br>
  * <br>
  * {@link #target} contains the Entity that was damaged by the player. <br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.event.entity.player;
 
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event.HasResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.event.entity.player;
 
 import java.util.List;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -37,8 +38,8 @@ public class ItemTooltipEvent extends PlayerEvent
     private final List<Component> toolTip;
 
     /**
-     * This event is fired in {@link ItemStack#getTooltip(EntityPlayer, ITooltipFlag)}, which in turn is called from it's respective GUIContainer.
-     * Tooltips are also gathered with a null entityPlayer during startup by {@link Minecraft#populateSearchTreeManager()}.
+     * This event is fired in {@link ItemStack#getTooltipLines(Player, TooltipFlag)}, which in turn is called from it's respective GUIContainer.
+     * Tooltips are also gathered with a null entityPlayer during startup by {@link Minecraft#createSearchTrees()}.
      */
     public ItemTooltipEvent(@Nonnull ItemStack itemStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags)
     {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
@@ -19,9 +19,22 @@
 
 package net.minecraftforge.event.entity.player;
 
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.ServerPlayerGameMode;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -29,16 +42,16 @@ import javax.annotation.Nullable;
 /**
  * PlayerDestroyItemEvent is fired when a player destroys an item.<br>
  * This event is fired whenever a player destroys an item in
- * {@link PlayerController#onPlayerDestroyBlock(BlockPos)},
- * {@link PlayerController#processRightClick(PlayerEntity, World, Hand)},
- * {@link PlayerController#processRightClickBlock(ClientPlayerEntity, ClientWorld, BlockPos, Direction, Vec3d, Hand)},
- * {@link PlayerEntity#attackTargetEntityWithCurrentItem(Entity)},
- * {@link PlayerEntity#damageShield(float)},
- * {@link PlayerEntity#interactOn(Entity, Hand)},
+ * {@link MultiPlayerGameMode#destroyBlock(BlockPos)},
+ * {@link MultiPlayerGameMode#useItem(Player, Level, InteractionHand)},
+ * {@link MultiPlayerGameMode#useItemOn(LocalPlayer, ClientLevel, InteractionHand, BlockHitResult)} ,
+ * {@link Player#attack(Entity)},
+ * {@code Player#hurtCurrentlyUsedShield(float)},
+ * {@link Player#interactOn(Entity, InteractionHand)},
  * {@link ForgeHooks#getContainerItem(ItemStack)},
- * {@link PlayerInteractionManager#processRightClick(PlayerEntity, World, ItemStack, Hand)},
- * {@link PlayerInteractionManager#processRightClickBlock(PlayerEntity, World, ItemStack, Hand, BlockPos, Direction, float, float, float)}
- * and {@link PlayerInteractionManager#tryHarvestBlock(BlockPos)}.<br>
+ * {@link ServerPlayerGameMode#useItem(ServerPlayer, Level, ItemStack, InteractionHand)} ,
+ * {@link ServerPlayerGameMode#useItemOn(ServerPlayer, Level, ItemStack, InteractionHand, BlockHitResult)}
+ * and {@link ServerPlayerGameMode#destroyBlock(BlockPos)}.<br>
  * <br>
  * {@link #original} contains the original ItemStack before the item was destroyed. <br>
  * (@link #hand) contains the hand that the current item was held in.<br>
@@ -47,7 +60,7 @@ import javax.annotation.Nullable;
  * <br>
  * This event does not have a result. {@link HasResult}<br>
  * <br>
- * This event is fired from {@link ForgeEventFactory#onPlayerDestroyItem(PlayerEntity, ItemStack, Hand)}.<br>
+ * This event is fired from {@link ForgeEventFactory#onPlayerDestroyItem(Player, ItemStack, InteractionHand)}.<br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 public class PlayerDestroyItemEvent extends PlayerEvent

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -21,12 +21,15 @@ package net.minecraftforge.event.entity.player;
 
 import java.io.File;
 
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
@@ -61,11 +64,11 @@ public class PlayerEvent extends LivingEvent
     /**
      * HarvestCheck is fired when a player attempts to harvest a block.<br>
      * This event is fired whenever a player attempts to harvest a block in
-     * {@link EntityPlayer#canHarvestBlock(IBlockState)}.<br>
+     * {@link Player#hasCorrectToolForDrops(BlockState)}.<br>
      * <br>
-     * This event is fired via the {@link ForgeEventFactory#doPlayerHarvestCheck(EntityPlayer, IBlockState, boolean)}.<br>
+     * This event is fired via the {@link ForgeEventFactory#doPlayerHarvestCheck(Player, BlockState, boolean)}.<br>
      * <br>
-     * {@link #state} contains the {@link IBlockState} that is being checked for harvesting. <br>
+     * {@link #state} contains the {@link BlockState} that is being checked for harvesting. <br>
      * {@link #success} contains the boolean value for whether the Block will be successfully harvested. <br>
      * <br>
      * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
@@ -94,9 +97,9 @@ public class PlayerEvent extends LivingEvent
     /**
      * BreakSpeed is fired when a player attempts to harvest a block.<br>
      * This event is fired whenever a player attempts to harvest a block in
-     * {@link EntityPlayer#canHarvestBlock(IBlockState)}.<br>
+     * {@link Player#getDigSpeed(BlockState, BlockPos)}.<br>
      * <br>
-     * This event is fired via the {@link ForgeEventFactory#getBreakSpeed(EntityPlayer, IBlockState, float, BlockPos)}.<br>
+     * This event is fired via the {@link ForgeEventFactory#getBreakSpeed(Player, BlockState, float, BlockPos)}.<br>
      * <br>
      * {@link #state} contains the block being broken. <br>
      * {@link #originalSpeed} contains the original speed at which the player broke the block. <br>
@@ -137,9 +140,9 @@ public class PlayerEvent extends LivingEvent
     /**
      * NameFormat is fired when a player's display name is retrieved.<br>
      * This event is fired whenever a player's name is retrieved in
-     * {@link EntityPlayer#getDisplayName()} or {@link EntityPlayer#refreshDisplayName()}.<br>
+     * {@link Player#getDisplayName()} or {@link Player#refreshDisplayName()}.<br>
      * <br>
-     * This event is fired via the {@link ForgeEventFactory#getPlayerDisplayName(EntityPlayer, String)}.<br>
+     * This event is fired via the {@link ForgeEventFactory#getPlayerDisplayName(Player, Component)}.<br>
      * <br>
      * {@link #username} contains the username of the player.
      * {@link #displayname} contains the display name of the player.
@@ -181,9 +184,9 @@ public class PlayerEvent extends LivingEvent
     /**
      * TabListNameFormat is fired when a player's display name for the tablist is retrieved.<br>
      * This event is fired whenever a player's display name for the tablist is retrieved in
-     * {@link ServerPlayerEntity#getTabListDisplayName()} or {@link ServerPlayerEntity#refreshTabListName()}.<br>
+     * {@link ServerPlayer#getTabListDisplayName()} or {@link ServerPlayer#refreshTabListName()}.<br>
      * <br>
-     * This event is fired via the {@link ForgeEventFactory#getPlayerTabListDisplayName(PlayerEntity)}.<br>
+     * This event is fired via the {@link ForgeEventFactory#getPlayerTabListDisplayName(Player)}.<br>
      * <br>
      * {@link #getDisplayName()} contains the display name of the player or null if the client should determine the display name itself.
      * <br>

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
@@ -22,6 +22,7 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.Player.BedSleepingProblem;
 import net.minecraft.core.BlockPos;
+import net.minecraftforge.common.MinecraftForge;
 
 import java.util.Optional;
 
@@ -29,7 +30,7 @@ import java.util.Optional;
  * PlayerSleepInBedEvent is fired when a player sleeps in a bed.
  * <br>
  * This event is fired whenever a player sleeps in a bed in
- * {@link EntityPlayer#trySleep(BlockPos)}.<br>
+ * {@link Player#startSleeping(BlockPos)}.<br>
  * <br>
  * {@link #result} contains whether the player is able to sleep. <br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
@@ -62,7 +63,7 @@ public class PlayerXpEvent extends PlayerEvent
     }
 
     /**
-     * This event is fired when the player's experience changes through the {@link PlayerEntity#giveExperiencePoints} method.
+     * This event is fired when the player's experience changes through the {@link Player#giveExperiencePoints(int)} method.
      * It can be cancelled, and no further processing will be done.
      */
     @Cancelable
@@ -90,7 +91,7 @@ public class PlayerXpEvent extends PlayerEvent
     }
 
     /**
-     * This event is fired when the player's experience level changes through the {@link PlayerEntity#addExperienceLevel} method.
+     * This event is fired when the player's experience level changes through the {@link Player#giveExperienceLevels(int)} method.
      * It can be cancelled, and no further processing will be done.
      */
     @Cancelable

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
@@ -19,8 +19,12 @@
 
 package net.minecraftforge.event.entity.player;
 
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.Event.HasResult;
 
@@ -31,7 +35,7 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * This event has a result. {@link HasResult}<br>
  *
  * setResult(ALLOW) informs game that player is still "in bed"<br>
- * setResult(DEFAULT) causes game to check {@link Block#isBed(IBlockState, net.minecraft.world.IWorldReader, BlockPos, Entity)} instead
+ * setResult(DEFAULT) causes game to check {@link Block#isBed(BlockState, BlockGetter, BlockPos, Entity)} instead
  */
 @HasResult
 public class SleepingLocationCheckEvent extends LivingEvent

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.eventbus.api.Event.HasResult;
 
 import java.util.Optional;
@@ -32,7 +33,7 @@ import java.util.Optional;
  * This event has a result. {@link HasResult}<br>
  *
  * setResult(ALLOW) informs game that player can sleep at this time.<br>
- * setResult(DEFAULT) causes game to check !{@link World#isDaytime()} instead.
+ * setResult(DEFAULT) causes game to check !{@link Level#isDay()} instead.
  */
 @HasResult
 public class SleepingTimeCheckEvent extends PlayerEvent

--- a/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
@@ -33,9 +33,9 @@ import net.minecraftforge.eventbus.api.Event;
 /**
  * {@link FurnaceFuelBurnTimeEvent} is fired when determining the fuel value for an ItemStack. <br>
  * <br>
- * To set the burn time of your own item, use {@link Item#getBurnTime(ItemStack)} instead.<br>
+ * To set the burn time of your own item, use {@link Item#getBurnTime(ItemStack, RecipeType)} instead.<br>
  * <br>
- * This event is fired from {@link ForgeEventFactory#getItemBurnTime(ItemStack)}.<br>
+ * This event is fired from {@link ForgeEventFactory#getItemBurnTime(ItemStack, int, RecipeType)}.<br>
  * <br>
  * This event is {@link Cancelable} to prevent later handlers from changing the value.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
@@ -23,12 +23,13 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.entity.ai.village.VillageSiege;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 /**
  * VillageSiegeEvent is fired just before a zombie siege finds a successful location in
- * {@link VillageSiege#trySetupSiege}, to give mods the chance to stop the siege.<br>
+ * {@code VillageSiege#tryToSetupSiege(ServerLevel)}, to give mods the chance to stop the siege.<br>
  * <br>
  * This event is {@link Cancelable}; canceling stops the siege.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/village/VillagerTradesEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillagerTradesEvent.java
@@ -22,8 +22,11 @@ package net.minecraftforge.event.village;
 import java.util.List;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.world.entity.npc.VillagerData;
 import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.npc.VillagerTrades.ItemListing;
+import net.minecraftforge.common.BasicTrade;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fmlserverevents.FMLServerAboutToStartEvent;
 

--- a/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
@@ -22,13 +22,15 @@ package net.minecraftforge.event.village;
 import java.util.List;
 
 import net.minecraft.world.entity.npc.VillagerTrades.ItemListing;
+import net.minecraftforge.common.BasicTrade;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fmlserverevents.FMLServerAboutToStartEvent;
 
 /**
  * WandererTradesEvent is fired during the {@link FMLServerAboutToStartEvent}.  It is used to gather the trade lists for the wandering merchant.
  * It is fired on the {@link MinecraftForge#EVENT_BUS}.
- * The wandering merchant picks a few trades from {@link TradeType#GENERIC} and a single trade from {@link TradeType#RARE}.
+ * The wandering merchant picks a few trades from {@code generic} and a single trade from {@code rare}.
  * To add trades to the merchant, simply add new trades to the list. {@link BasicTrade} provides a default implementation.
 */
 public class WandererTradesEvent extends Event

--- a/src/main/java/net/minecraftforge/event/world/BiomeLoadingEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BiomeLoadingEvent.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraftforge.common.world.BiomeGenerationSettingsBuilder;
 import net.minecraftforge.common.world.MobSpawnInfoBuilder;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -270,7 +270,7 @@ public class BlockEvent extends Event
     }
 
     /**
-     * Fired when a liquid places a block. Use {@link #setNewState(IBlockState)} to change the result of
+     * Fired when a liquid places a block. Use {@link #setNewState(BlockState)} to change the result of
      * a cobblestone generator or add variants of obsidian. Alternatively, you  could execute
      * arbitrary code when lava sets blocks on fire, even preventing it.
      *
@@ -431,7 +431,7 @@ public class BlockEvent extends Event
     /**
      * Fired when when this block is right clicked by a tool to change its state.
      * For example: Used to determine if an axe can strip or a shovel can path.
-     * For hoes, see {@link net.minecraft.world.item.HoeItem#TILLABLES} and
+     * For hoes, see {@code net.minecraft.world.item.HoeItem#TILLABLES} and
      * {@link net.minecraftforge.event.entity.player.UseHoeEvent}.
      *
      * This event is {@link Cancelable}. If canceled, this will prevent the tool

--- a/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
@@ -20,9 +20,16 @@
 package net.minecraftforge.event.world;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.village.poi.PoiManager;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
 
 /**
  * ChunkDataEvent is fired when an event involving chunk data occurs.<br>
@@ -57,7 +64,7 @@ public class ChunkDataEvent extends ChunkEvent
     /**
      * ChunkDataEvent.Load is fired when vanilla Minecraft attempts to load Chunk data.<br>
      * This event is fired during chunk loading in
-     * {@link net.minecraft.world.chunk.storage.ChunkSerializer.read(ServerWorld, TemplateManager, PointOfInterestManager, ChunkPos, CompoundNBT)} which means it is async, so be careful.<br>
+     * {@link net.minecraft.world.level.chunk.storage.ChunkSerializer#read(ServerLevel, StructureManager, PoiManager, ChunkPos, CompoundTag)} which means it is async, so be careful.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -84,7 +91,7 @@ public class ChunkDataEvent extends ChunkEvent
     /**
      * ChunkDataEvent.Save is fired when vanilla Minecraft attempts to save Chunk data.<br>
      * This event is fired during chunk saving in
-     * {@link AnvilChunkLoader#saveChunk(World, Chunk)}. <br>
+     * {@code ChunkMap#save(ChunkAccess)}. <br>
      * <br>
      * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
@@ -26,6 +26,7 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.storage.ChunkSerializer;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -64,7 +65,7 @@ public class ChunkDataEvent extends ChunkEvent
     /**
      * ChunkDataEvent.Load is fired when vanilla Minecraft attempts to load Chunk data.<br>
      * This event is fired during chunk loading in
-     * {@link net.minecraft.world.level.chunk.storage.ChunkSerializer#read(ServerLevel, StructureManager, PoiManager, ChunkPos, CompoundTag)} which means it is async, so be careful.<br>
+     * {@link ChunkSerializer#read(ServerLevel, StructureManager, PoiManager, ChunkPos, CompoundTag)} which means it is async, so be careful.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
@@ -21,6 +21,9 @@ package net.minecraftforge.event.world;
 
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.ChunkStatus;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraftforge.common.MinecraftForge;
 
 /**
  * ChunkEvent is fired when an event involving a chunk occurs.<br>
@@ -55,9 +58,9 @@ public class ChunkEvent extends WorldEvent
     /**
      * ChunkEvent.Load is fired when vanilla Minecraft attempts to load a Chunk into the world.<br>
      * This event is fired during chunk loading in <br>
-     * {@link ChunkProviderClient#loadChunk(int, int)}, <br>
+     * {@code ChunkProviderClient#loadChunk(int, int)}, <br>
      * Chunk.onChunkLoad(). <br>
-     * <strong>Note:</strong> This event may be called before the underlying {@link net.minecraft.world.chunk.Chunk} is promoted to {@link net.minecraft.world.chunk.ChunkStatus#FULL}. You will cause chunk loading deadlocks if you don't delay your world interactions.<br>
+     * <strong>Note:</strong> This event may be called before the underlying {@link LevelChunk} is promoted to {@link ChunkStatus#FULL}. You will cause chunk loading deadlocks if you don't delay your world interactions.<br>
      * <br>
      * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
@@ -19,15 +19,23 @@
 
 package net.minecraftforge.event.world;
 
+import net.minecraft.client.multiplayer.ClientChunkCache;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import java.util.BitSet;
 
 /**
  * ChunkEvent is fired when an event involving a chunk occurs.<br>
- * If a method utilizes this {@link net.minecraftforge.eventbus.api.Event} as its parameter, the method will
+ * If a method utilizes this {@link Event} as its parameter, the method will
  * receive every child event of this class.<br>
  * <br>
  * {@link #chunk} contains the Chunk this event is affecting.<br>
@@ -58,11 +66,11 @@ public class ChunkEvent extends WorldEvent
     /**
      * ChunkEvent.Load is fired when vanilla Minecraft attempts to load a Chunk into the world.<br>
      * This event is fired during chunk loading in <br>
-     * {@code ChunkProviderClient#loadChunk(int, int)}, <br>
+     * {@link ClientChunkCache#replaceWithPacketData(int, int, ChunkBiomeContainer, FriendlyByteBuf, CompoundTag, BitSet)}, <br>
      * Chunk.onChunkLoad(). <br>
      * <strong>Note:</strong> This event may be called before the underlying {@link LevelChunk} is promoted to {@link ChunkStatus#FULL}. You will cause chunk loading deadlocks if you don't delay your world interactions.<br>
      * <br>
-     * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * This event is not {@link Cancelable}.<br>
      * <br>
      * This event does not have a result. {@link HasResult} <br>
      * <br>
@@ -81,7 +89,7 @@ public class ChunkEvent extends WorldEvent
      * This event is fired during chunk unloading in <br>
      * Chunk.onChunkUnload(). <br>
      * <br>
-     * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+     * This event is not {@link Cancelable}.<br>
      * <br>
      * This event does not have a result. {@link HasResult} <br>
      * <br>

--- a/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -22,6 +22,7 @@ package net.minecraftforge.event.world;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 
 /**
@@ -69,7 +70,7 @@ public class ChunkWatchEvent extends Event
     /**
      * ChunkWatchEvent.Watch is fired when an EntityPlayer begins watching a chunk.<br>
      * This event is fired when a chunk is added to the watched chunks of an EntityPlayer in
-     * {@link net.minecraft.world.server.ChunkManager#setChunkLoadedAtClient}. <br>
+     * {@code net.minecraft.server.level.ChunkMap#updateChunkTracking(ServerPlayer, ChunkPos, Packet[], boolean, boolean)}. <br>
      * <br>
      * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
      * <br>
@@ -85,7 +86,7 @@ public class ChunkWatchEvent extends Event
     /**
      * ChunkWatchEvent.UnWatch is fired when an EntityPlayer stops watching a chunk.<br>
      * This event is fired when a chunk is removed from the watched chunks of an EntityPlayer in
-     * {@link net.minecraft.world.server.ChunkManager#setChunkLoadedAtClient}. <br>
+     * {@code net.minecraft.server.level.ChunkMap#updateChunkTracking(ServerPlayer, ChunkPos, Packet[], boolean, boolean)}. <br>
      * <br>
      * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/event/world/ExplosionEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ExplosionEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.event.world;
 
 import java.util.List;
 
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.world.entity.Entity;

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -74,7 +74,7 @@ public abstract class PistonEvent extends BlockEvent
     }
 
     /**
-     * @return A piston structure helper for this movement. Returns null if the world stored is not a {@link World}
+     * @return A piston structure helper for this movement. Returns null if the world stored is not a {@link Level}
      */
     @Nullable
     public PistonStructureResolver getStructureHelper()

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -39,7 +39,6 @@ public abstract class PistonEvent extends BlockEvent
     /**
      * @param world
      * @param pos - The position of the piston
-     * @param direction - The direction of the piston
      * @param direction - The move direction of the piston
      */
     public PistonEvent(Level world, BlockPos pos, Direction direction, PistonMoveType moveType)

--- a/src/main/java/net/minecraftforge/event/world/SaplingGrowTreeEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/SaplingGrowTreeEvent.java
@@ -22,13 +22,16 @@ package net.minecraftforge.event.world;
 import java.util.Random;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event.HasResult;
 
 /**
  * SaplingGrowTreeEvent is fired when a sapling grows into a tree.<br>
  * This event is fired during sapling growth in
- * {@link BlockSapling#generateTree(World, BlockPos, IBlockState, Random)}.<br>
+ * {@link net.minecraft.world.level.block.SaplingBlock#advanceTree(ServerLevel, BlockPos, BlockState, Random)} .<br>
  * <br>
  * {@link #pos} contains the coordinates of the growing sapling. <br>
  * {@link #rand} contains an instance of Random for use. <br>
@@ -38,7 +41,7 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * This event has a result. {@link HasResult} <br>
  * This result determines if the sapling is allowed to grow. <br>
  * <br>
- * This event is fired on the {@link MinecraftForge#TERRAIN_GEN_BUS}.<br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
 @HasResult
 public class SaplingGrowTreeEvent extends WorldEvent

--- a/src/main/java/net/minecraftforge/event/world/SaplingGrowTreeEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/SaplingGrowTreeEvent.java
@@ -24,19 +24,21 @@ import java.util.Random;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.SaplingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event.HasResult;
 
 /**
  * SaplingGrowTreeEvent is fired when a sapling grows into a tree.<br>
  * This event is fired during sapling growth in
- * {@link net.minecraft.world.level.block.SaplingBlock#advanceTree(ServerLevel, BlockPos, BlockState, Random)} .<br>
+ * {@link SaplingBlock#advanceTree(ServerLevel, BlockPos, BlockState, Random)} .<br>
  * <br>
  * {@link #pos} contains the coordinates of the growing sapling. <br>
  * {@link #rand} contains an instance of Random for use. <br>
  * <br>
- * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+ * This event is not {@link Cancelable}.<br>
  * <br>
  * This event has a result. {@link HasResult} <br>
  * This result determines if the sapling is allowed to grow. <br>

--- a/src/main/java/net/minecraftforge/event/world/StructureSpawnListGatherEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/StructureSpawnListGatherEvent.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.biome.MobSpawnSettings.SpawnerData;
 import net.minecraft.world.level.levelgen.feature.StructureFeature;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
 
 /**
  * This event fires when a Structure is gathering what mobs/creatures can spawn in it.

--- a/src/main/java/net/minecraftforge/event/world/WorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/WorldEvent.java
@@ -19,14 +19,23 @@
 
 package net.minecraftforge.event.world;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.function.Supplier;
 
-import net.minecraft.world.entity.MobCategory;
-import net.minecraft.core.BlockPos;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.ProgressListener;
 import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.biome.MobSpawnSettings;
+import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.storage.ServerLevelData;
+import net.minecraftforge.common.ForgeInternalHandler;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 /**
@@ -55,11 +64,8 @@ public class WorldEvent extends Event
     /**
      * WorldEvent.Load is fired when Minecraft loads a world.<br>
      * This event is fired when a world is loaded in
-     * {@link WorldClient#WorldClient(NetHandlerPlayClient, WorldSettings, int, EnumDifficulty, Profiler)},
-     * {@link MinecraftServer#loadAllWorlds(String, String, long, WorldType, String)},
-     * {@link IntegratedServer#loadAllWorlds(String, String, long, WorldType, String)}
-     * {@link DimensionManager#initDimension(int)},
-     * and {@link ForgeInternalHandler#onDimensionLoad(Load)}. <br>
+     * {@link ClientLevel#ClientLevel(ClientPacketListener, ClientLevel.ClientLevelData, ResourceKey, DimensionType, int, Supplier, LevelRenderer, boolean, long)},
+     * {@code MinecraftServer#createLevels(ChunkProgressListener)}. <br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -75,9 +81,9 @@ public class WorldEvent extends Event
     /**
      * WorldEvent.Unload is fired when Minecraft unloads a world.<br>
      * This event is fired when a world is unloaded in
-     * {@link Minecraft#loadWorld(WorldClient, String)},
-     * {@link MinecraftServer#stopServer()},
-     * {@link DimensionManager#unloadWorlds()},
+     * {@link Minecraft#setLevel(ClientLevel)},
+     * {@link MinecraftServer#stopServer()},,
+     * {@link Minecraft#clearLevel(Screen)}
      * {@link ForgeInternalHandler#onDimensionUnload(Unload)}. <br>
      * <br>
      * This event is not {@link Cancelable}.<br>
@@ -94,8 +100,7 @@ public class WorldEvent extends Event
     /**
      * WorldEvent.Save is fired when Minecraft saves a world.<br>
      * This event is fired when a world is saved in
-     * {@link WorldServer#saveAllChunks(boolean, IProgressUpdate)},
-     * {@link ForgeInternalHandler#onDimensionSave(Save)}. <br>
+     * {@link ServerLevel#save(ProgressListener, boolean, boolean)}. <br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fluids;
 import javax.annotation.Nullable;
 
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.item.ItemStack;
@@ -44,6 +45,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.phys.BlockHitResult;
 
 /**
  * Minecraft Forge Fluid Implementation
@@ -186,7 +188,7 @@ public class FluidAttributes
      * Determines if this fluid should vaporize in dimensions where water vaporizes when placed.
      * To preserve the intentions of vanilla, fluids that can turn lava into obsidian should vaporize.
      * This prevents players from making the nether safe with a single bucket.
-     * Based on {@link net.minecraft.item.BucketItem#tryPlaceContainedLiquid(PlayerEntity, World, BlockPos)}
+     * Based on {@link net.minecraft.world.item.BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
      *
      * @param fluidStack The fluidStack is trying to be placed.
      * @return true if this fluid should vaporize in dimensions where water vaporizes when placed.
@@ -200,9 +202,9 @@ public class FluidAttributes
     }
 
     /**
-     * Called instead of placing the fluid block if {@link net.minecraft.world.dimension.Dimension#doesWaterVaporize()} and {@link #doesVaporize(FluidStack)} are true.
+     * Called instead of placing the fluid block if {@link DimensionType#ultraWarm()} and {@link #doesVaporize(BlockAndTintGetter, BlockPos, FluidStack)} are true.
      * Override this to make your explosive liquid blow up instead of the default smoke, etc.
-     * Based on {@link net.minecraft.item.BucketItem#tryPlaceContainedLiquid(PlayerEntity, World, BlockPos)}
+     * Based on {@link net.minecraft.world.item.BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
      *
      * @param player     Player who tried to place the fluid. May be null for blocks like dispensers.
      * @param worldIn    World to vaporize the fluid in.

--- a/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
@@ -21,6 +21,7 @@ package net.minecraftforge.fluids;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.material.Fluid;
@@ -188,7 +189,7 @@ public class FluidAttributes
      * Determines if this fluid should vaporize in dimensions where water vaporizes when placed.
      * To preserve the intentions of vanilla, fluids that can turn lava into obsidian should vaporize.
      * This prevents players from making the nether safe with a single bucket.
-     * Based on {@link net.minecraft.world.item.BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
+     * Based on {@link BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
      *
      * @param fluidStack The fluidStack is trying to be placed.
      * @return true if this fluid should vaporize in dimensions where water vaporizes when placed.
@@ -204,7 +205,7 @@ public class FluidAttributes
     /**
      * Called instead of placing the fluid block if {@link DimensionType#ultraWarm()} and {@link #doesVaporize(BlockAndTintGetter, BlockPos, FluidStack)} are true.
      * Override this to make your explosive liquid blow up instead of the default smoke, etc.
-     * Based on {@link net.minecraft.world.item.BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
+     * Based on {@link BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
      *
      * @param player     Player who tried to place the fluid. May be null for blocks like dispensers.
      * @param worldIn    World to vaporize the fluid in.

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -130,7 +130,7 @@ public class FluidUtil
      *
      * @param container   The container to be filled. Will not be modified.
      *                    Separate handling must be done to reduce the stack size, stow containers, etc, on success.
-     *                    See {@link  #tryFillContainerAndStow(ItemStack, IFluidHandler, IItemHandler, int, PlayerEntity, boolean)}.
+     *                    See {@link #tryFillContainerAndStow(ItemStack, IFluidHandler, IItemHandler, int, Player, boolean)}.
      * @param fluidSource The fluid handler to be drained.
      * @param maxAmount   The largest amount of fluid that should be transferred.
      * @param player      The player to make the filling noise. Pass null for no noise.
@@ -173,7 +173,7 @@ public class FluidUtil
      *
      * @param container        The filled container. Will not be modified.
      *                         Separate handling must be done to reduce the stack size, stow containers, etc, on success.
-     *                         See {@link #tryEmptyContainerAndStow(ItemStack, IFluidHandler, IItemHandler, int, PlayerEntity, boolean)}.
+     *                         See {@link #tryEmptyContainerAndStow(ItemStack, IFluidHandler, IItemHandler, int, Player, boolean)}.
      * @param fluidDestination The fluid handler to be filled by the container.
      * @param maxAmount        The largest amount of fluid that should be transferred.
      * @param player           Player for making the bucket drained sound. Pass null for no noise.
@@ -514,11 +514,11 @@ public class FluidUtil
     }
 
     /**
-     * ItemStack version of {@link #tryPlaceFluid(PlayerEntity, World, Hand, BlockPos, IFluidHandler, FluidStack)}.
+     * ItemStack version of {@link #tryPlaceFluid(Player, Level, InteractionHand, BlockPos, IFluidHandler, FluidStack)}.
      * Use the returned {@link FluidActionResult} to update the container ItemStack.
      *
      * @param player    Player who places the fluid. May be null for blocks like dispensers.
-     * @param world     World to place the fluid in
+     * @param world     Level to place the fluid in
      * @param hand
      * @param pos       The position in the world to place the fluid block
      * @param container The fluid container holding the fluidStack to place
@@ -542,10 +542,10 @@ public class FluidUtil
      * Honors the amount of fluid contained by the used container.
      * Checks if water-like fluids should vaporize like in the nether.
      *
-     * Modeled after {@link net.minecraft.item.BucketItem#tryPlaceContainedLiquid(PlayerEntity, World, BlockPos, BlockRayTraceResult)}
+     * Modeled after {@link net.minecraft.world.item.BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
      *
      * @param player      Player who places the fluid. May be null for blocks like dispensers.
-     * @param world       World to place the fluid in
+     * @param world       Level to place the fluid in
      * @param hand
      * @param pos         The position in the world to place the fluid block
      * @param fluidSource The fluid source holding the fluidStack to place
@@ -618,8 +618,8 @@ public class FluidUtil
     /**
      * Internal method for getting a fluid block handler for placing a fluid.
      *
-     * Modders: Instead of this method, use {@link #tryPlaceFluid(PlayerEntity, World, Hand, BlockPos, ItemStack, FluidStack)}
-     * or {@link #tryPlaceFluid(PlayerEntity, World, Hand, BlockPos, IFluidHandler, FluidStack)}
+     * Modders: Instead of this method, use {@link #tryPlaceFluid(Player, Level, InteractionHand, BlockPos, ItemStack, FluidStack)}
+     * or {@link #tryPlaceFluid(Player, Level, InteractionHand, BlockPos, IFluidHandler, FluidStack)}
      */
     private static IFluidHandler getFluidBlockHandler(Fluid fluid, Level world, BlockPos pos)
     {
@@ -629,9 +629,9 @@ public class FluidUtil
 
     /**
      * Destroys a block when a fluid is placed in the same position.
-     * Modeled after {@link net.minecraft.item.BucketItem#tryPlaceContainedLiquid(PlayerEntity, World, BlockPos, BlockRayTraceResult)}
+     * Modeled after {@link net.minecraft.world.item.BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
      *
-     * This is a helper method for implementing {@link IFluidBlock#place(World, BlockPos, FluidStack, IFluidHandler.FluidAction)}.
+     * This is a helper method for implementing {@link IFluidBlock#place(Level, BlockPos, FluidStack, IFluidHandler.FluidAction)}.
      *
      * @param world the world that the fluid will be placed in
      * @param pos   the location that the fluid will be placed

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -23,6 +23,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
+import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.BucketPickup;
 import net.minecraft.world.level.block.LiquidBlockContainer;
@@ -542,7 +543,7 @@ public class FluidUtil
      * Honors the amount of fluid contained by the used container.
      * Checks if water-like fluids should vaporize like in the nether.
      *
-     * Modeled after {@link net.minecraft.world.item.BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
+     * Modeled after {@link BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
      *
      * @param player      Player who places the fluid. May be null for blocks like dispensers.
      * @param world       Level to place the fluid in
@@ -629,7 +630,7 @@ public class FluidUtil
 
     /**
      * Destroys a block when a fluid is placed in the same position.
-     * Modeled after {@link net.minecraft.world.item.BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
+     * Modeled after {@link BucketItem#emptyContents(Player, Level, BlockPos, BlockHitResult)}
      *
      * This is a helper method for implementing {@link IFluidBlock#place(Level, BlockPos, FluidStack, IFluidHandler.FluidAction)}.
      *

--- a/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
+++ b/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
@@ -29,8 +29,6 @@ import javax.annotation.Nonnull;
 /**
  * Implement this interface on Block classes which represent world-placeable Fluids.
  *
- * NOTE: Using/extending the reference implementations {@link BlockFluidBase} is encouraged.
- *
  */
 public interface IFluidBlock
 {

--- a/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
@@ -26,7 +26,7 @@ import net.minecraftforge.fluids.*;
 /**
  * Implement this interface as a capability which should handle fluids, generally storing them in
  * one or more internal {@link IFluidTank} objects.
- * <p/>
+ * <p>
  * A reference implementation is provided {@link TileFluidHandler}.
  */
 public interface IFluidHandler
@@ -110,7 +110,7 @@ public interface IFluidHandler
 
     /**
      * Drains fluid out of internal tanks, distribution is left entirely to the IFluidHandler.
-     * <p/>
+     * <p>
      * This method is not Fluid-sensitive.
      *
      * @param maxDrain Maximum amount of fluid to drain.

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/BlockWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/BlockWrapper.java
@@ -33,8 +33,8 @@ import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 
 /**
  * Wrapper around any block, only accounts for fluid placement, otherwise the block acts a void.
- * If the block in question inherits from the default Vanilla or Forge implementations,
- * consider using {@link BlockLiquidWrapper} or {@link FluidBlockWrapper} respectively.
+ * If the block in question inherits from the Forge implementations,
+ * consider using {@link FluidBlockWrapper}.
  */
 public class BlockWrapper extends VoidFluidHandler
 {

--- a/src/main/java/net/minecraftforge/fmllegacy/network/FMLHandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/FMLHandshakeHandler.java
@@ -21,8 +21,10 @@ package net.minecraftforge.fmllegacy.network;
 
 import com.google.common.collect.Multimap;
 import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.login.ServerboundCustomQueryPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.server.network.ServerLoginPacketListenerImpl;
 import net.minecraftforge.common.util.LogMessageAdapter;
 import net.minecraftforge.fmllegacy.network.simple.SimpleChannel;
 import net.minecraftforge.fmllegacy.util.ThreeConsumer;
@@ -47,24 +49,24 @@ import static net.minecraftforge.registries.ForgeRegistry.REGISTRIES;
 /**
  * Instance responsible for handling the overall FML network handshake.
  *
- * <p>An instance is created during {@link net.minecraft.network.handshake.client.CHandshakePacket} handling, and attached
- * to the {@link NetworkManager#channel} via {@link FMLNetworkConstants#FML_HANDSHAKE_HANDLER}.
+ * <p>An instance is created during {@link net.minecraft.network.protocol.handshake.ClientIntentionPacket} handling, and attached
+ * to the {@link Connection#channel()} via {@link FMLNetworkConstants#FML_HANDSHAKE_HANDLER}.
  *
  * <p>The {@link FMLNetworkConstants#handshakeChannel} is a {@link SimpleChannel} with standard messages flowing in both directions.
  *
- * <p>The {@link #loginWrapper} transforms these messages into {@link net.minecraft.network.login.client.CCustomPayloadLoginPacket}
- * and {@link net.minecraft.network.login.server.SCustomPayloadLoginPacket} compatible messages, by means of wrapping.
+ * <p>The {@link #loginWrapper} transforms these messages into {@link net.minecraft.network.protocol.login.ServerboundCustomQueryPacket}
+ * and {@link net.minecraft.network.protocol.login.ClientboundCustomQueryPacket} compatible messages, by means of wrapping.
  *
- * <p>The handshake is ticked {@link #tickLogin(NetworkManager)} from the {@link ServerLoginNetHandler#update()} method,
- * utilizing the {@link ServerLoginNetHandler.State#NEGOTIATING} state, which is otherwise unused in vanilla code.
+ * <p>The handshake is ticked {@code #tickLogin(NetworkManager)} from the {@link ServerLoginPacketListenerImpl#tick()} method,
+ * utilizing the {@code ServerLoginPacketListenerImpl.State#NEGOTIATING} state, which is otherwise unused in vanilla code.
  *
  * <p>During client to server initiation, on the <em>server</em>, the {@link NetworkEvent.GatherLoginPayloadsEvent} is fired,
  * which solicits all registered channels at the {@link NetworkRegistry} for any
  * {@link NetworkRegistry.LoginPayload} they wish to supply.
  *
  * <p>The collected {@link NetworkRegistry.LoginPayload} are sent, one per tick, via
- * the {@link FMLLoginWrapper#wrapPacket(ResourceLocation, PacketBuffer)} mechanism to the incoming client connection. Each
- * packet is indexed via {@link net.minecraft.network.login.client.CCustomPayloadLoginPacket#transaction}, which is
+ * the {@code FMLLoginWrapper#wrapPacket(ResourceLocation, net.minecraft.network.FriendlyByteBuf)} mechanism to the incoming client connection. Each
+ * packet is indexed via {@link ServerboundCustomQueryPacket#getTransactionId()}, which is
  * the only mechanism available for tracking request/response pairs.
  *
  * <p>Each packet sent from the server should be replied by the client, though not necessarily in sent order. The reply
@@ -84,7 +86,7 @@ public class FMLHandshakeHandler {
     }
 
     /**
-     * Create a new handshake instance. Called when connection is first created during the {@link net.minecraft.network.handshake.client.CHandshakePacket}
+     * Create a new handshake instance. Called when connection is first created during the {@link net.minecraft.network.protocol.handshake.ClientIntentionPacket}
      * handling.
      *
      * @param manager The network manager for this connection
@@ -141,7 +143,7 @@ public class FMLHandshakeHandler {
     }
 
     /**
-     * Transforms a two-argument instance method reference into a {@link BiConsumer} {@link #biConsumerFor(ThreeConsumer)}, first calling the {@link #handleIndexedMessage(FMLHandshakeMessages.LoginIndexedMessage, Supplier)}
+     * Transforms a two-argument instance method reference into a {@link BiConsumer} {@link #biConsumerFor(ThreeConsumer)}, first calling the {@link #handleIndexedMessage(IntSupplier, Supplier)}
      * method to handle index tracking. Used for client to server replies.
      *
      * This should only be used for login messages.

--- a/src/main/java/net/minecraftforge/fmllegacy/network/FMLHandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/FMLHandshakeHandler.java
@@ -21,6 +21,8 @@ package net.minecraftforge.fmllegacy.network;
 
 import com.google.common.collect.Multimap;
 import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.handshake.ClientIntentionPacket;
+import net.minecraft.network.protocol.login.ClientboundCustomQueryPacket;
 import net.minecraft.network.protocol.login.ServerboundCustomQueryPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.chat.TextComponent;
@@ -49,13 +51,13 @@ import static net.minecraftforge.registries.ForgeRegistry.REGISTRIES;
 /**
  * Instance responsible for handling the overall FML network handshake.
  *
- * <p>An instance is created during {@link net.minecraft.network.protocol.handshake.ClientIntentionPacket} handling, and attached
+ * <p>An instance is created during {@link ClientIntentionPacket} handling, and attached
  * to the {@link Connection#channel()} via {@link FMLNetworkConstants#FML_HANDSHAKE_HANDLER}.
  *
  * <p>The {@link FMLNetworkConstants#handshakeChannel} is a {@link SimpleChannel} with standard messages flowing in both directions.
  *
- * <p>The {@link #loginWrapper} transforms these messages into {@link net.minecraft.network.protocol.login.ServerboundCustomQueryPacket}
- * and {@link net.minecraft.network.protocol.login.ClientboundCustomQueryPacket} compatible messages, by means of wrapping.
+ * <p>The {@link #loginWrapper} transforms these messages into {@link ServerboundCustomQueryPacket}
+ * and {@link ClientboundCustomQueryPacket} compatible messages, by means of wrapping.
  *
  * <p>The handshake is ticked {@code #tickLogin(NetworkManager)} from the {@link ServerLoginPacketListenerImpl#tick()} method,
  * utilizing the {@code ServerLoginPacketListenerImpl.State#NEGOTIATING} state, which is otherwise unused in vanilla code.
@@ -86,7 +88,7 @@ public class FMLHandshakeHandler {
     }
 
     /**
-     * Create a new handshake instance. Called when connection is first created during the {@link net.minecraft.network.protocol.handshake.ClientIntentionPacket}
+     * Create a new handshake instance. Called when connection is first created during the {@link ClientIntentionPacket}
      * handling.
      *
      * @param manager The network manager for this connection

--- a/src/main/java/net/minecraftforge/fmllegacy/network/FMLNetworkConstants.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/FMLNetworkConstants.java
@@ -50,7 +50,7 @@ public class FMLNetworkConstants
     static final SimpleChannel playChannel = NetworkInitialization.getPlayChannel();
     static final List<EventNetworkChannel> mcRegChannels = NetworkInitialization.buildMCRegistrationChannels();
     /**
-     * Return this value in your {@link net.minecraftforge.fml.ExtensionPoint#DISPLAYTEST} function to be ignored.
+     * Return this value in your {@link net.minecraftforge.fml.IExtensionPoint.DisplayTest} function to be ignored.
      */
     public static final String IGNORESERVERONLY = "OHNOES\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31";
 

--- a/src/main/java/net/minecraftforge/fmllegacy/network/FMLNetworkConstants.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/FMLNetworkConstants.java
@@ -21,6 +21,7 @@ package net.minecraftforge.fmllegacy.network;
 
 import io.netty.util.AttributeKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.fml.IExtensionPoint.DisplayTest;
 import net.minecraftforge.fmllegacy.network.event.EventNetworkChannel;
 import net.minecraftforge.fmllegacy.network.simple.SimpleChannel;
 import org.apache.logging.log4j.Marker;
@@ -50,7 +51,7 @@ public class FMLNetworkConstants
     static final SimpleChannel playChannel = NetworkInitialization.getPlayChannel();
     static final List<EventNetworkChannel> mcRegChannels = NetworkInitialization.buildMCRegistrationChannels();
     /**
-     * Return this value in your {@link net.minecraftforge.fml.IExtensionPoint.DisplayTest} function to be ignored.
+     * Return this value in your {@link DisplayTest} function to be ignored.
      */
     public static final String IGNORESERVERONLY = "OHNOES\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31";
 

--- a/src/main/java/net/minecraftforge/fmllegacy/network/FMLPlayMessages.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/FMLPlayMessages.java
@@ -45,7 +45,7 @@ public class FMLPlayMessages
 {
     /**
      * Used to spawn a custom entity without the same restrictions as
-     * {@link net.minecraft.network.play.server.SSpawnObjectPacket} or {@link net.minecraft.network.play.server.SSpawnMobPacket}
+     * {@link net.minecraft.network.protocol.game.ClientboundAddEntityPacket} or {@link net.minecraft.network.protocol.game.ClientboundAddMobPacket}
      *
      * To customize how your entity is created clientside (instead of using the default factory provided to the {@link EntityType})
      * see {@link EntityType.Builder#setCustomClientFactory}.

--- a/src/main/java/net/minecraftforge/fmllegacy/network/FMLPlayMessages.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/FMLPlayMessages.java
@@ -25,6 +25,8 @@ import net.minecraft.client.gui.screens.inventory.MenuAccess;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
+import net.minecraft.network.protocol.game.ClientboundAddMobPacket;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -45,7 +47,7 @@ public class FMLPlayMessages
 {
     /**
      * Used to spawn a custom entity without the same restrictions as
-     * {@link net.minecraft.network.protocol.game.ClientboundAddEntityPacket} or {@link net.minecraft.network.protocol.game.ClientboundAddMobPacket}
+     * {@link ClientboundAddEntityPacket} or {@link ClientboundAddMobPacket}
      *
      * To customize how your entity is created clientside (instead of using the default factory provided to the {@link EntityType})
      * see {@link EntityType.Builder#setCustomClientFactory}.

--- a/src/main/java/net/minecraftforge/fmllegacy/network/FMLStatusPing.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/FMLStatusPing.java
@@ -54,7 +54,7 @@ import java.util.stream.StreamSupport;
  *     "mods": [
  *          {
  *              "modid": "modid",
- *              "modmarker": "<somestring>"
+ *              "modmarker": "{@literal <somestring>}"
  *          }
  *     ]
  * }

--- a/src/main/java/net/minecraftforge/fmllegacy/network/NetworkEvent.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/NetworkEvent.java
@@ -158,7 +158,7 @@ public class NetworkEvent extends Event
     public static class Context
     {
         /**
-         * The {@link NetworkManager} for this message.
+         * The {@link Connection} for this message.
          */
         private final Connection networkManager;
 

--- a/src/main/java/net/minecraftforge/fmllegacy/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/NetworkHooks.java
@@ -158,12 +158,8 @@ public class NetworkHooks
     /**
      * Request to open a GUI on the client, from the server
      *
-     * Refer to {@link net.minecraftforge.fml.ExtensionPoint#CONFIGGUIFACTORY} for how to provide a function to consume
+     * Refer to {@link net.minecraftforge.fml.IExtensionPoint.DisplayTest} for how to provide a function to consume
      * these GUI requests on the client.
-     *
-     * The {@link IInteractionObject#getGuiID()} is treated as a {@link ResourceLocation}.
-     * It should refer to a valid modId namespace, to trigger opening on the client.
-     * The namespace is directly used to lookup the modId in the client side.
      *
      * @param player The player to open the GUI for
      * @param containerSupplier A supplier of container properties including the registry name of the container
@@ -176,12 +172,8 @@ public class NetworkHooks
     /**
      * Request to open a GUI on the client, from the server
      *
-     * Refer to {@link net.minecraftforge.fml.ExtensionPoint#CONFIGGUIFACTORY} for how to provide a function to consume
+     * Refer to {@link net.minecraftforge.fml.IExtensionPoint.DisplayTest} for how to provide a function to consume
      * these GUI requests on the client.
-     *
-     * The {@link IInteractionObject#getGuiID()} is treated as a {@link ResourceLocation}.
-     * It should refer to a valid modId namespace, to trigger opening on the client.
-     * The namespace is directly used to lookup the modId in the client side.
      *
      * @param player The player to open the GUI for
      * @param containerSupplier A supplier of container properties including the registry name of the container
@@ -194,12 +186,9 @@ public class NetworkHooks
     /**
      * Request to open a GUI on the client, from the server
      *
-     * Refer to {@link net.minecraftforge.fml.ExtensionPoint#CONFIGGUIFACTORY} for how to provide a function to consume
+     * Refer to {@link net.minecraftforge.fml.IExtensionPoint.DisplayTest} for how to provide a function to consume
      * these GUI requests on the client.
      *
-     * The {@link IInteractionObject#getGuiID()} is treated as a {@link ResourceLocation}.
-     * It should refer to a valid modId namespace, to trigger opening on the client.
-     * The namespace is directly used to lookup the modId in the client side.
      * The maximum size for #extraDataWriter is 32600 bytes.
      *
      * @param player The player to open the GUI for

--- a/src/main/java/net/minecraftforge/fmllegacy/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/NetworkHooks.java
@@ -33,6 +33,7 @@ import net.minecraft.tags.TagCollection;
 import net.minecraft.tags.TagContainer;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraftforge.fml.util.thread.EffectiveSide;
+import net.minecraftforge.fmlclient.ConfigGuiHandler.ConfigGuiFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -158,7 +159,7 @@ public class NetworkHooks
     /**
      * Request to open a GUI on the client, from the server
      *
-     * Refer to {@link net.minecraftforge.fml.IExtensionPoint.DisplayTest} for how to provide a function to consume
+     * Refer to {@link ConfigGuiFactory} for how to provide a function to consume
      * these GUI requests on the client.
      *
      * @param player The player to open the GUI for
@@ -172,7 +173,7 @@ public class NetworkHooks
     /**
      * Request to open a GUI on the client, from the server
      *
-     * Refer to {@link net.minecraftforge.fml.IExtensionPoint.DisplayTest} for how to provide a function to consume
+     * Refer to {@link ConfigGuiFactory} for how to provide a function to consume
      * these GUI requests on the client.
      *
      * @param player The player to open the GUI for
@@ -186,7 +187,7 @@ public class NetworkHooks
     /**
      * Request to open a GUI on the client, from the server
      *
-     * Refer to {@link net.minecraftforge.fml.IExtensionPoint.DisplayTest} for how to provide a function to consume
+     * Refer to {@link ConfigGuiFactory} for how to provide a function to consume
      * these GUI requests on the client.
      *
      * The maximum size for #extraDataWriter is 32600 bytes.

--- a/src/main/java/net/minecraftforge/fmllegacy/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/NetworkRegistry.java
@@ -257,7 +257,7 @@ public class NetworkRegistry
     }
 
     /**
-     * Retrieve the {@link LoginPayload} list for dispatch during {@code FMLHandshakeHandler#tickLogin(Connection)} handling.
+     * Retrieve the {@link LoginPayload} list for dispatch during {@link FMLHandshakeHandler#tickLogin(Connection)} handling.
      * Dispatches {@link NetworkEvent.GatherLoginPayloadsEvent} to each {@link NetworkInstance}.
      *
      * @return The {@link LoginPayload} list

--- a/src/main/java/net/minecraftforge/fmllegacy/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/fmllegacy/network/NetworkRegistry.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fmllegacy.network;
 
+import net.minecraft.network.Connection;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fmllegacy.network.event.EventNetworkChannel;
@@ -256,7 +257,7 @@ public class NetworkRegistry
     }
 
     /**
-     * Retrieve the {@link LoginPayload} list for dispatch during {@link FMLHandshakeHandler#tickLogin(NetworkManager)} handling.
+     * Retrieve the {@link LoginPayload} list for dispatch during {@code FMLHandshakeHandler#tickLogin(Connection)} handling.
      * Dispatches {@link NetworkEvent.GatherLoginPayloadsEvent} to each {@link NetworkInstance}.
      *
      * @return The {@link LoginPayload} list

--- a/src/main/java/net/minecraftforge/fmlserverevents/FMLServerAboutToStartEvent.java
+++ b/src/main/java/net/minecraftforge/fmlserverevents/FMLServerAboutToStartEvent.java
@@ -22,7 +22,7 @@ package net.minecraftforge.fmlserverevents;
 import net.minecraft.server.MinecraftServer;
 
 /**
- * Called before the server begins loading anything. Called after {@link InterModProcessEvent} on the dedicated
+ * Called before the server begins loading anything. Called after {@link net.minecraftforge.fml.event.lifecycle.InterModProcessEvent} on the dedicated
  * server, and after the player has hit "Play Selected World" in the client. Called before {@link FMLServerStartingEvent}.
  *
  * You can obtain a reference to the server with this event.

--- a/src/main/java/net/minecraftforge/fmlserverevents/FMLServerAboutToStartEvent.java
+++ b/src/main/java/net/minecraftforge/fmlserverevents/FMLServerAboutToStartEvent.java
@@ -20,9 +20,10 @@
 package net.minecraftforge.fmlserverevents;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
 
 /**
- * Called before the server begins loading anything. Called after {@link net.minecraftforge.fml.event.lifecycle.InterModProcessEvent} on the dedicated
+ * Called before the server begins loading anything. Called after {@link InterModProcessEvent} on the dedicated
  * server, and after the player has hit "Play Selected World" in the client. Called before {@link FMLServerStartingEvent}.
  *
  * You can obtain a reference to the server with this event.

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -20,6 +20,9 @@
 package net.minecraftforge.items;
 
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+
 import javax.annotation.Nonnull;
 
 
@@ -59,7 +62,7 @@ public interface IItemHandler
      * Inserts an ItemStack into the given slot and return the remainder.
      * The ItemStack <em>should not</em> be modified in this function!
      * </p>
-     * Note: This behaviour is subtly different from {@link IFluidHandler#fill(FluidStack, boolean)}
+     * Note: This behaviour is subtly different from {@link IFluidHandler#fill(FluidStack, IFluidHandler.FluidAction)}
      *
      * @param slot     Slot to insert into.
      * @param stack    ItemStack to insert. This must not be modified by the item handler.
@@ -97,7 +100,7 @@ public interface IItemHandler
 
     /**
      * <p>
-     * This function re-implements the vanilla function {@link IInventory#isItemValidForSlot(int, ItemStack)}.
+     * This function re-implements the vanilla function {@link net.minecraft.world.Container#canPlaceItem(int, ItemStack)}.
      * It should be used instead of simulated insertions in cases where the contents and state of the inventory are
      * irrelevant, mainly for the purpose of automation and logic (for instance, testing if a minecart can wait
      * to deposit its items into a full inventory, or if the items in the minecart can never be placed into the

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.items;
 
+import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
@@ -100,7 +101,7 @@ public interface IItemHandler
 
     /**
      * <p>
-     * This function re-implements the vanilla function {@link net.minecraft.world.Container#canPlaceItem(int, ItemStack)}.
+     * This function re-implements the vanilla function {@link Container#canPlaceItem(int, ItemStack)}.
      * It should be used instead of simulated insertions in cases where the contents and state of the inventory are
      * irrelevant, mainly for the purpose of automation and logic (for instance, testing if a minecart can wait
      * to deposit its items into a full inventory, or if the items in the minecart can never be placed into the

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityArmorInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityArmorInvWrapper.java
@@ -21,10 +21,12 @@ package net.minecraftforge.items.wrapper;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
 
 /**
- * Exposes the armor inventory of an {@link EntityLivingBase} as an {@link IItemHandler} using {@link EntityLivingBase#getItemStackFromSlot} and
- * {@link EntityLivingBase#setItemStackToSlot}.
+ * Exposes the armor inventory of an {@link LivingEntity} as an {@link IItemHandler} using {@link LivingEntity#getItemBySlot(EquipmentSlot)} and
+ * {@link LivingEntity#setItemSlot(EquipmentSlot, ItemStack)}.
  */
 public class EntityArmorInvWrapper extends EntityEquipmentInvWrapper
 {

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
@@ -24,6 +24,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
 import java.util.ArrayList;
@@ -32,8 +33,8 @@ import javax.annotation.Nonnull;
 
 
 /**
- * Exposes the armor or hands inventory of an {@link EntityLivingBase} as an {@link IItemHandler} using {@link EntityLivingBase#getItemStackFromSlot} and
- * {@link EntityLivingBase#setItemStackToSlot}.
+ * Exposes the armor or hands inventory of an {@link LivingEntity} as an {@link IItemHandler} using {@link LivingEntity#getItemBySlot(EquipmentSlot)} and
+ * {@link LivingEntity#setItemSlot(EquipmentSlot, ItemStack)}.
  */
 public abstract class EntityEquipmentInvWrapper implements IItemHandlerModifiable
 {
@@ -43,7 +44,7 @@ public abstract class EntityEquipmentInvWrapper implements IItemHandlerModifiabl
     protected final LivingEntity entity;
 
     /**
-     * The slots exposed by this wrapper, with {@link EntityEquipmentSlot#index} as the index.
+     * The slots exposed by this wrapper, with {@link EquipmentSlot#getIndex()} as the index.
      */
     protected final List<EquipmentSlot> slots;
 

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityHandsInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityHandsInvWrapper.java
@@ -21,10 +21,12 @@ package net.minecraftforge.items.wrapper;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
 
 /**
- * Exposes the hands inventory of an {@link EntityLivingBase} as an {@link IItemHandler} using {@link EntityLivingBase#getItemStackFromSlot} and
- * {@link EntityLivingBase#setItemStackToSlot}.
+ * Exposes the hands inventory of an {@link LivingEntity} as an {@link IItemHandler} using {@link LivingEntity#getItemBySlot(EquipmentSlot)} and
+ * {@link LivingEntity#setItemSlot(EquipmentSlot, ItemStack)}.
  */
 public class EntityHandsInvWrapper extends EntityEquipmentInvWrapper
 {

--- a/src/main/java/net/minecraftforge/items/wrapper/RecipeWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RecipeWrapper.java
@@ -34,7 +34,7 @@ public class RecipeWrapper implements Container {
     }
 
     /**
-     * Returns the size of this inventory.  Must be equivalent to {@link #getHeight()} * {@link #getWidth()}.
+     * Returns the size of this inventory.
      */
     @Override
     public int getContainerSize()

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -40,7 +40,7 @@ import java.util.function.Supplier;
  * Suppliers should return NEW instances every time.
  *
  *Example Usage:
- *<pre>
+ *<pre>{@code
  *   private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
  *   private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
  *
@@ -51,7 +51,7 @@ import java.util.function.Supplier;
  *       ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
  *       BLOCKS.register(FMLJavaModLoadingContext.get().getModEventBus());
  *   }
- *</pre>
+ *}</pre>
  *
  * @param <T> The base registry type, must be a concrete base class, do not use subclasses or wild cards.
  */

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -62,7 +62,7 @@ import net.minecraftforge.common.world.ForgeWorldType;
 /**
  * A class that exposes static references to all vanilla and Forge registries.
  * Created to have a central place to access the registries directly if modders need.
- * It is still advised that if you are registering things to go through {@link GameRegistry} register methods, but queries and iterations can use this.
+ * It is still advised that if you are registering things to go through {@link net.minecraftforge.fmllegacy.common.registry.GameRegistry} register methods, but queries and iterations can use this.
  */
 public class ForgeRegistries
 {

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -58,11 +58,12 @@ import net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecoratorTy
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.common.world.ForgeWorldType;
+import net.minecraftforge.fmllegacy.common.registry.GameRegistry;
 
 /**
  * A class that exposes static references to all vanilla and Forge registries.
  * Created to have a central place to access the registries directly if modders need.
- * It is still advised that if you are registering things to go through {@link net.minecraftforge.fmllegacy.common.registry.GameRegistry} register methods, but queries and iterations can use this.
+ * It is still advised that if you are registering things to go through {@link GameRegistry} register methods, but queries and iterations can use this.
  */
 public class ForgeRegistries
 {

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -663,7 +663,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
 
     /**
      * Used to control the times where people can modify this registry.
-     * Users should only ever register things in the Register<?> events!
+     * Users should only ever register things in the {@literal Register<?>} events!
      */
     public void freeze()
     {

--- a/src/main/java/net/minecraftforge/server/permission/DefaultPermissionLevel.java
+++ b/src/main/java/net/minecraftforge/server/permission/DefaultPermissionLevel.java
@@ -20,7 +20,8 @@
 package net.minecraftforge.server.permission;
 
 /**
- * <table><thead><tr><th>Level</th><th>Player</th><th>OP</th></tr>
+ * <table><caption>Default Permission Levels</caption>
+ * <thead><tr><th>Level</th><th>Player</th><th>OP</th></tr>
  * </thead><tbody>
  * <tr><td>ALL</td><td>true</td><td>true</td></tr>
  * <tr><td>OP</td><td>false</td><td>true</td></tr>


### PR DESCRIPTION
This PR aims to perform the first step of cleanup for the javadocs, by removing all errors (usually caused by references to non-existent classes or inaccessible members) in javadocs. It is not a goal of this PR to rewrite, reword, add to, or improve the existing javadocs except when doing so is required to eliminate the error.