### PR TITLE
Remove/fix redundant warning suppression

### DIFF
--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/BackgroundScanHandler.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/BackgroundScanHandler.java
@@ -51,7 +51,6 @@ public class BackgroundScanHandler
     private ScanStatus status;
     private LoadingModList loadingModList;
 
-    @SuppressWarnings("UnstableApiUsage")
     public BackgroundScanHandler(final List<ModFile> modFiles) {
         this.modFiles = modFiles;
         modContentScanner = Executors.newSingleThreadExecutor(r -> {

--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -65,7 +65,6 @@ import com.mojang.blaze3d.systems.RenderSystem;
 
 import javax.annotation.Nullable;
 
-@SuppressWarnings("deprecation")
 public class ForgeIngameGui extends Gui
 {
     private static final Logger LOGGER = LogManager.getLogger();

--- a/src/main/java/net/minecraftforge/client/gui/NotificationModUpdateScreen.java
+++ b/src/main/java/net/minecraftforge/client/gui/NotificationModUpdateScreen.java
@@ -63,7 +63,6 @@ public class NotificationModUpdateScreen extends Screen
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void render(PoseStack mStack, int mouseX, int mouseY, float partialTicks)
     {

--- a/src/main/java/net/minecraftforge/client/loading/EarlyLoaderGUI.java
+++ b/src/main/java/net/minecraftforge/client/loading/EarlyLoaderGUI.java
@@ -45,7 +45,6 @@ public class EarlyLoaderGUI {
         this.window = minecraft.getWindow();
     }
 
-    @SuppressWarnings("deprecation")
     private void setupMatrix() {
         RenderSystem.clear(256, Minecraft.ON_OSX);
         GL11.glMatrixMode(5889);
@@ -64,7 +63,6 @@ public class EarlyLoaderGUI {
         renderMessages();
     }
 
-    @SuppressWarnings("deprecation")
     void renderTick() {
         if (handledElsewhere) return;
         // int guiScale = window.calculateScale(0, false);
@@ -128,7 +126,6 @@ public class EarlyLoaderGUI {
         renderMessage(memory, memorycolour, 1, 1.0f);
     }
 
-    @SuppressWarnings("deprecation")
     void renderMessage(final String message, final float[] colour, int line, float alpha) {
         // GL11.glEnableClientState(GL11.GL_VERTEX_ARRAY);
         // ByteBuffer charBuffer = MemoryUtil.memAlloc(message.length() * 270);

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -420,16 +420,20 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, EnumGetMethod converter) {
             return defineEnum(path, defaultValue, converter, defaultValue.getDeclaringClass().getEnumConstants());
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, @SuppressWarnings("unchecked") V... acceptableValues) {
+        @SuppressWarnings("unchecked")
+        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, V... acceptableValues) {
             return defineEnum(split(path), defaultValue, acceptableValues);
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, EnumGetMethod converter, @SuppressWarnings("unchecked") V... acceptableValues) {
+        @SuppressWarnings("unchecked")
+        public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, EnumGetMethod converter, V... acceptableValues) {
             return defineEnum(split(path), defaultValue, converter, acceptableValues);
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, @SuppressWarnings("unchecked") V... acceptableValues) {
+        @SuppressWarnings("unchecked")
+        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, V... acceptableValues) {
             return defineEnum(path, defaultValue, (Collection<V>) Arrays.asList(acceptableValues));
         }
-        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, EnumGetMethod converter, @SuppressWarnings("unchecked") V... acceptableValues) {
+        @SuppressWarnings("unchecked")
+        public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, EnumGetMethod converter, V... acceptableValues) {
             return defineEnum(path, defaultValue, converter, Arrays.asList(acceptableValues));
         }
         public <V extends Enum<V>> EnumValue<V> defineEnum(String path, V defaultValue, Collection<V> acceptableValues) {
@@ -441,7 +445,6 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
         public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, Collection<V> acceptableValues) {
             return defineEnum(path, defaultValue, EnumGetMethod.NAME_IGNORECASE, acceptableValues);
         }
-        @SuppressWarnings("unchecked")
         public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, V defaultValue, EnumGetMethod converter, Collection<V> acceptableValues) {
             return defineEnum(path, defaultValue, converter, obj -> {
                 if (obj instanceof Enum) {

--- a/src/main/java/net/minecraftforge/common/util/TablePrinter.java
+++ b/src/main/java/net/minecraftforge/common/util/TablePrinter.java
@@ -68,7 +68,8 @@ public class TablePrinter<T>
         return this;
     }
 
-    public TablePrinter<T> add(T row, @SuppressWarnings("unchecked") T... more)
+    @SuppressWarnings("unchecked")
+    public TablePrinter<T> add(T row, T... more)
     {
         add(row);
         for (T t : more)

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -180,8 +180,9 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
         return tagFolder;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public void registerAll(@SuppressWarnings("unchecked") V... values)
+    public void registerAll(V... values)
     {
         for (V value : values)
             register(value);

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -336,7 +336,6 @@ public class GameData
         LOGGER.debug(REGISTRIES, "Reverting complete");
     }
 
-    @SuppressWarnings("rawtypes") //Eclipse compiler generics issue.
     public static Stream<IModStateTransition.EventGenerator<?>> generateRegistryEvents() {
         List<ResourceLocation> keys = Lists.newArrayList(RegistryManager.ACTIVE.registries.keySet());
         keys.sort((o1, o2) -> String.valueOf(o1).compareToIgnoreCase(String.valueOf(o2)));

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -41,7 +41,8 @@ public interface IForgeRegistry<V extends IForgeRegistryEntry<V>> extends Iterab
 
     void register(V value);
 
-    void registerAll(@SuppressWarnings("unchecked") V... values);
+    @SuppressWarnings("unchecked")
+    void registerAll(V... values);
 
     boolean containsKey(ResourceLocation key);
     boolean containsValue(V value);

--- a/src/test/java/net/minecraftforge/debug/client/CustomTooltipTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/CustomTooltipTest.java
@@ -332,13 +332,11 @@ public class CustomTooltipTest
         }
 
         // legacy ToolTip methods
-        @SuppressWarnings("removal")
         private void test13(Button button, PoseStack poseStack, int mouseX, int mouseY)
         {
             renderTooltip(poseStack, List.of(new TextComponent("test").getVisualOrderText()), mouseX, mouseY, this.testFont);
         }
 
-        @SuppressWarnings("removal")
         private void test14(Button button, PoseStack poseStack, int mouseX, int mouseY)
         {
             renderComponentTooltip(poseStack, List.of(new TextComponent("test")), mouseX, mouseY, this.testFont, ItemStack.EMPTY);


### PR DESCRIPTION
Removes and fixes redundant warning suppression. 

- Removes redundant warning suppression annotations.  
- Fixes `unchecked` suppression on methods with varargs parameters*. 

\* Not sure if this is different for eclipse but IntelliJ does not support these unchecked suppressions on the parameter level, fixed by moving to method level. Another solution for non-abstract methods is making them final and annotating with `@SafeVarargs`. 

### Note on `resource` suppressions
IntelliJ also seems to reckon that the `resource` suppressions (e.g. in `EntityViewRenderEvent$FogColors` constructor) are redundant. From what I understand of this suppression the instances are valid as the methods in question do leak an `AutoCloseable`, so my thinking is that IntelliJ does not properly support these annotations. For this reason they have been left untouched. 