### PR TITLE
Minor Javadoc cleanup

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/minecraftforge/client/gui/ModListScreen.java
@@ -118,9 +118,6 @@ public class ModListScreen extends Screen
     private boolean sorted = false;
     private SortType sortType = SortType.NORMAL;
 
-    /**
-     * @param parentScreen
-     */
     public ModListScreen(Screen parentScreen)
     {
         super(new TranslatableComponent("fml.menu.mods.title"));

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -200,7 +200,6 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
 
     /**
      * Use a custom loader instead of the vanilla elements.
-     * @param customLoaderFactory
      * @return the custom loader builder
      */
     public <L extends CustomLoaderBuilder<T>> L customLoader(BiFunction<T, ExistingFileHelper, L> customLoaderFactory)

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -200,6 +200,7 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
 
     /**
      * Use a custom loader instead of the vanilla elements.
+     * @param customLoaderFactory function that returns the custom loader to set, given this and the {@link #existingFileHelper}
      * @return the custom loader builder
      */
     public <L extends CustomLoaderBuilder<T>> L customLoader(BiFunction<T, ExistingFileHelper, L> customLoaderFactory)

--- a/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
+++ b/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
@@ -104,6 +104,11 @@ public class ExistingFileHelper {
      * <p>
      * Only create a new helper if you intentionally want to ignore the existence of
      * other generated files.
+     * @param existingPacks a collection of paths to existing packs
+     * @param existingMods a set of mod IDs for existing mods
+     * @param enable {@code true} if validation is enabled
+     * @param assetIndex the identifier for the asset index, generally Minecraft's current major version
+     * @param assetsDir the directory in which to find vanilla assets and indexes
      */
     public ExistingFileHelper(Collection<Path> existingPacks, final Set<String> existingMods, boolean enable, @Nullable final String assetIndex, @Nullable final File assetsDir) {
         this.clientResources = new SimpleReloadableResourceManager(PackType.CLIENT_RESOURCES);

--- a/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
+++ b/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
@@ -104,12 +104,6 @@ public class ExistingFileHelper {
      * <p>
      * Only create a new helper if you intentionally want to ignore the existence of
      * other generated files.
-     * 
-     * @param existingPacks
-     * @param existingMods
-     * @param enable
-     * @param assetIndex
-     * @param assetsDir
      */
     public ExistingFileHelper(Collection<Path> existingPacks, final Set<String> existingMods, boolean enable, @Nullable final String assetIndex, @Nullable final File assetsDir) {
         this.clientResources = new SimpleReloadableResourceManager(PackType.CLIENT_RESOURCES);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeAbstractMinecart.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeAbstractMinecart.java
@@ -124,8 +124,6 @@ public interface IForgeAbstractMinecart
      * functions differs from getMaxCartSpeedOnRail() in that it controls
      * current movement and cannot be overridden. The value however can never be
      * higher than getMaxCartSpeedOnRail().
-     *
-     * @return
      */
     float getCurrentCartSpeedCapOnRail();
     void setCurrentCartSpeedCapOnRail(float value);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -387,6 +387,8 @@ public interface IForgeBlock
     * @param state The current state
     * @param world The world
     * @param pos Block position
+    * @param fortune fortune enchantment level of tool being used
+    * @param silktouch silk touch enchantment level of tool being used
     * @return Amount of XP from breaking this block.
     */
     default int getExpDrop(BlockState state, LevelReader world, BlockPos pos, int fortune, int silktouch)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -90,9 +90,6 @@ public interface IForgeBlock
     /**
      * Get a light value for this block, taking into account the given state and coordinates, normal ranges are between 0 and 15
      *
-     * @param state
-     * @param world
-     * @param pos
      * @return The light value
      */
     default int getLightEmission(BlockState state, BlockGetter world, BlockPos pos)
@@ -235,7 +232,6 @@ public interface IForgeBlock
     /**
      * Called when a user either starts or stops sleeping in the bed.
      *
-     * @param state
      * @param world The current world
      * @param pos Block position in world
      * @param sleeper The sleeper or camera entity, null in some cases.
@@ -391,7 +387,6 @@ public interface IForgeBlock
     * @param state The current state
     * @param world The world
     * @param pos Block position
-    * @param fortune
     * @return Amount of XP from breaking this block.
     */
     default int getExpDrop(BlockState state, LevelReader world, BlockPos pos, int fortune, int silktouch)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -329,7 +329,6 @@ public interface IForgeBlockState
     *
     * @param world The world
     * @param pos Block position
-    * @param fortune
     * @return Amount of XP from breaking this block.
     */
     default int getExpDrop(LevelReader world, BlockPos pos, int fortune, int silktouch)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -329,6 +329,8 @@ public interface IForgeBlockState
     *
     * @param world The world
     * @param pos Block position
+    * @param fortune fortune enchantment level of tool being used
+    * @param silktouch silk touch enchantment level of tool being used
     * @return Amount of XP from breaking this block.
     */
     default int getExpDrop(LevelReader world, BlockPos pos, int fortune, int silktouch)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -332,7 +332,6 @@ public interface IForgeItem
      * @param world  The world
      * @param pos    Block position in world
      * @param player The Player that is wielding the item
-     * @return
      */
     default boolean doesSneakBypassUse(ItemStack stack, net.minecraft.world.level.LevelReader world, BlockPos pos, Player player)
     {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -370,7 +370,6 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
      * @param world The world
      * @param pos Block position in world
      * @param player The Player that is wielding the item
-     * @return
      */
     default boolean doesSneakBypassUse(net.minecraft.world.level.LevelReader world, BlockPos pos, Player player)
     {

--- a/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
@@ -139,7 +139,6 @@ public class LootModifierManager extends SimpleJsonResourceReloadListener {
 
     /**
      * An immutable collection of the registered loot modifiers in layered order.
-     * @return
      */
     public Collection<IGlobalLootModifier> getAllLootMods() {
         return registeredLootModifiers.values();

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -318,7 +318,6 @@ public class PlayerEvent extends LivingEvent
         /**
          * Construct and return a recommended file for the supplied suffix
          * @param suffix The suffix to use.
-         * @return
          */
         public File getPlayerFile(String suffix)
         {
@@ -371,7 +370,6 @@ public class PlayerEvent extends LivingEvent
         /**
          * Construct and return a recommended file for the supplied suffix
          * @param suffix The suffix to use.
-         * @return
          */
         public File getPlayerFile(String suffix)
         {

--- a/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
@@ -65,7 +65,7 @@ public class ChunkDataEvent extends ChunkEvent
     /**
      * ChunkDataEvent.Load is fired when vanilla Minecraft attempts to load Chunk data.<br>
      * This event is fired during chunk loading in
-     * {@link ChunkSerializer#read(ServerLevel, StructureManager, PoiManager, ChunkPos, CompoundTag)} which means it is async, so be careful.<br>
+     * {@link ChunkSerializer#read(ServerLevel, PoiManager, ChunkPos, CompoundTag)} which means it is async, so be careful.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -37,7 +37,6 @@ public abstract class PistonEvent extends BlockEvent
     private final PistonMoveType moveType;
 
     /**
-     * @param world
      * @param pos - The position of the piston
      * @param direction - The move direction of the piston
      */

--- a/src/main/java/net/minecraftforge/event/world/WorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/WorldEvent.java
@@ -64,7 +64,7 @@ public class WorldEvent extends Event
     /**
      * WorldEvent.Load is fired when Minecraft loads a world.<br>
      * This event is fired when a world is loaded in
-     * {@link ClientLevel#ClientLevel(ClientPacketListener, ClientLevel.ClientLevelData, ResourceKey, DimensionType, int, Supplier, LevelRenderer, boolean, long)},
+     * {@link ClientLevel#ClientLevel(ClientPacketListener, ClientLevel.ClientLevelData, ResourceKey, DimensionType, int, int, Supplier, LevelRenderer, boolean, long)},
      * {@code MinecraftServer#createLevels(ChunkProgressListener)}. <br>
      * <br>
      * This event is not {@link Cancelable}.<br>

--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -293,7 +293,6 @@ public class FluidStack
     /**
      * Determines if the Fluids are equal and this stack is larger.
      *
-     * @param other
      * @return true if this FluidStack contains the other FluidStack (same fluid and >= amount)
      */
     public boolean containsFluid(@Nonnull FluidStack other)

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -520,7 +520,6 @@ public class FluidUtil
      *
      * @param player    Player who places the fluid. May be null for blocks like dispensers.
      * @param world     Level to place the fluid in
-     * @param hand
      * @param pos       The position in the world to place the fluid block
      * @param container The fluid container holding the fluidStack to place
      * @param resource  The fluidStack to place
@@ -547,7 +546,6 @@ public class FluidUtil
      *
      * @param player      Player who places the fluid. May be null for blocks like dispensers.
      * @param world       Level to place the fluid in
-     * @param hand
      * @param pos         The position in the world to place the fluid block
      * @param fluidSource The fluid source holding the fluidStack to place
      * @param resource    The fluidStack to place.

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -520,6 +520,7 @@ public class FluidUtil
      *
      * @param player    Player who places the fluid. May be null for blocks like dispensers.
      * @param world     Level to place the fluid in
+     * @param hand      hand of the player to place the fluid with
      * @param pos       The position in the world to place the fluid block
      * @param container The fluid container holding the fluidStack to place
      * @param resource  The fluidStack to place
@@ -546,6 +547,7 @@ public class FluidUtil
      *
      * @param player      Player who places the fluid. May be null for blocks like dispensers.
      * @param world       Level to place the fluid in
+     * @param hand        hand of the player to place the fluid with
      * @param pos         The position in the world to place the fluid block
      * @param fluidSource The fluid source holding the fluidStack to place
      * @param resource    The fluidStack to place.

--- a/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
+++ b/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
@@ -58,7 +58,6 @@ public interface IFluidBlock
      *
      * @param action
      *            If SIMULATE, the drain will only be simulated.
-     * @return
      */
     @Nonnull
     FluidStack drain(Level world, BlockPos pos, IFluidHandler.FluidAction action);
@@ -66,8 +65,6 @@ public interface IFluidBlock
     /**
      * Check to see if a block can be drained. This method should be called by devices such as
      * pumps.
-     *
-     * @return
      */
     boolean canDrain(Level world, BlockPos pos);
 
@@ -77,8 +74,6 @@ public interface IFluidBlock
      *
      * If the return value is negative. It will be treated as filling the block
      * from the top down instead of bottom up.
-     *
-     * @return
      */
     float getFilledPercentage(Level world, BlockPos pos);
 }

--- a/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
+++ b/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
@@ -58,6 +58,7 @@ public interface IFluidBlock
      *
      * @param action
      *            If SIMULATE, the drain will only be simulated.
+     * @return the fluid stack after draining the block
      */
     @Nonnull
     FluidStack drain(Level world, BlockPos pos, IFluidHandler.FluidAction action);

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -59,11 +59,11 @@ import net.minecraftforge.common.world.ForgeWorldPreset;
 /**
  * A class that exposes static references to all vanilla and Forge registries.
  * Created to have a central place to access the registries directly if modders need.
- * It is still advised that if you are registering things to go through {@link GameRegistry} register methods, but queries and iterations can use this.
+ * It is still advised that if you are registering things to use {@link net.minecraftforge.event.RegistryEvent.Register} or {@link net.minecraftforge.registries.DeferredRegister}, but queries and iterations can use this.
  */
 public class ForgeRegistries
 {
-    static { init(); } // This must be above the fields so we guarantee it's run before findRegistry is called. Yay static inializers
+    static { init(); } // This must be above the fields so we guarantee it's run before getRegistry is called. Yay static inializers
 
     // Game objects
     public static final IForgeRegistry<Block> BLOCKS = RegistryManager.ACTIVE.getRegistry(Block.class);


### PR DESCRIPTION
Various minor Javadoc fixes/cleanup across Forge classes. 

- Replaced references to the removed `GameRegistry` class and its `findRegistry` method.
- Fixed `@link` tags with unresolved references. 
- Removed Javadoc tags without a description.  