### PR TITLE
Minor cleanup to MDK build.gradle

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -8,12 +8,13 @@ buildscript {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
     }
 }
-apply plugin: 'net.minecraftforge.gradle'
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 plugins {
     id 'eclipse'
     id 'maven-publish'
 }
+apply plugin: 'net.minecraftforge.gradle'
+
 
 version = '1.0'
 group = 'com.yourname.modid' // http://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -65,16 +65,8 @@ minecraft {
         server {
             workingDirectory project.file('run')
 
-            // Recommended logging data for a userdev environment
-            // The markers can be added/remove as needed separated by commas.
-            // "SCAN": For mods scan.
-            // "REGISTRIES": For firing of registry events.
-            // "REGISTRYDUMP": For getting the contents of all registries.
             property 'forge.logging.markers', 'REGISTRIES'
 
-            // Recommended logging level for the console
-            // You can set various levels here.
-            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
             property 'forge.logging.console.level', 'debug'
 
             mods {
@@ -87,16 +79,8 @@ minecraft {
         data {
             workingDirectory project.file('run')
 
-            // Recommended logging data for a userdev environment
-            // The markers can be added/remove as needed separated by commas.
-            // "SCAN": For mods scan.
-            // "REGISTRIES": For firing of registry events.
-            // "REGISTRYDUMP": For getting the contents of all registries.
             property 'forge.logging.markers', 'REGISTRIES'
 
-            // Recommended logging level for the console
-            // You can set various levels here.
-            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
             property 'forge.logging.console.level', 'debug'
 
             // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -20,7 +20,7 @@ archivesBaseName = 'modid'
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
-println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
+println "Java: ${System.getProperty('java.version')}, JVM: ${System.getProperty('java.vm.version')} (${System.getProperty('java.vendor')}), Arch: ${System.getProperty('os.arch')}"
 minecraft {
     // The mappings can be changed at any time and must be in the following format.
     // Channel:   Version:

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -24,12 +24,14 @@ println "Java: ${System.getProperty('java.version')}, JVM: ${System.getProperty(
 minecraft {
     // The mappings can be changed at any time and must be in the following format.
     // Channel:   Version:
-    // snapshot   YYYYMMDD   Snapshot are built nightly.
-    // stable     #          Stables are built at the discretion of the MCP team.
-    // official   MCVersion  Official field/method names from Mojang mapping files
+    // official   MCVersion                   Official field/method names from Mojang mapping files
+    // parchment  ParchmentVersion-MCVersion  Open community-sourced parameter names and javadocs on top of official
     //
-    // You must be aware of the Mojang license when using the 'official' mappings.
+    // You must be aware of the Mojang license when using the 'official' or 'parchment' mappings.
     // See more information here: https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
+    //
+    // Parchment is an unofficial project, separate from MinecraftForge
+    // Additional setup is needed in order to use their mappings: https://github.com/ParchmentMC/Parchment/wiki/Getting-Started
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -10,8 +10,10 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle'
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
-apply plugin: 'eclipse'
-apply plugin: 'maven-publish'
+plugins {
+    id 'eclipse'
+    id 'maven-publish'
+}
 
 version = '1.0'
 group = 'com.yourname.modid' // http://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -20,7 +20,7 @@ archivesBaseName = 'modid'
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
-println "Java: ${System.getProperty('java.version')}, JVM: ${System.getProperty('java.vm.version')} (${System.getProperty('java.vendor')}), Arch: ${System.getProperty('os.arch')}"
+println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 minecraft {
     // The mappings can be changed at any time and must be in the following format.
     // Channel:   Version:

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -24,14 +24,14 @@ println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty '
 minecraft {
     // The mappings can be changed at any time and must be in the following format.
     // Channel:   Version:
-    // official   MCVersion                   Official field/method names from Mojang mapping files
-    // parchment  ParchmentVersion-MCVersion  Open community-sourced parameter names and javadocs on top of official
+    // official   MCVersion             Official field/method names from Mojang mapping files
+    // parchment  YYYY.MM.DD-MCVersion  Open community-sourced parameter names and javadocs layered on top of official
     //
     // You must be aware of the Mojang license when using the 'official' or 'parchment' mappings.
     // See more information here: https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
     //
-    // Parchment is an unofficial project, separate from MinecraftForge
-    // Additional setup is needed in order to use their mappings: https://github.com/ParchmentMC/Parchment/wiki/Getting-Started
+    // Parchment is an unofficial project maintained by ParchmentMC, separate from MinecraftForge
+    // Additional setup is needed to use their mappings: https://github.com/ParchmentMC/Parchment/wiki/Getting-Started
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.


### PR DESCRIPTION
Used separate commits to facilitate cherry-picking changes if desired.

Summary of changes:
- The java info println has been replaced with a shorter, Groovier version. It could be even shorter, but I opted for this version to avoid false-positive syntax highlighting errors in IntelliJ
- The java info println's output is slightly improved:
    - Before: `Java: 17.0.1 JVM: 17.0.1+12(Eclipse Adoptium) Arch: amd64`
    - After:   `Java: 17.0.1, JVM: 17.0.1+12 (Eclipse Adoptium), Arch: amd64`
- Duplicate help comments in run configs have been deleted to make the build.gradle's LoC shorter and less overwhelming to new devs
- Removed mention of MCP from the mappings help comment as it is no longer officially available for 1.17 onwards
- Added mention of Parchment mappings to the help comment
- Used new plugin definition format for eclipse and maven-publish