### PR TITLE
Fix IPv4/IPv6 dual-stack patches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -384,7 +384,8 @@ def sharedFmlonlyForge = { Project prj ->
 
                 property 'nativesDirectory', '{natives}'
 
-                args '-Djava.net.preferIPv6Addresses=system'
+                jvmArgs '-Djava.net.preferIPv6Addresses=system'
+
                 args '--launchTarget', "${launchPrefix}clientuserdev"
                 args '--version', 'MOD_DEV'
                 args '--assetIndex', '{asset_index}'
@@ -395,7 +396,8 @@ def sharedFmlonlyForge = { Project prj ->
                 environment 'MOD_CLASSES', '{source_roots}'
                 environment 'MCP_MAPPINGS', '{mcp_mappings}'
 
-                args '-Djava.net.preferIPv6Addresses=system'
+                jvmArgs '-Djava.net.preferIPv6Addresses=system'
+
                 args '--launchTarget', "${launchPrefix}serveruserdev"
             }
 

--- a/build.gradle
+++ b/build.gradle
@@ -384,6 +384,7 @@ def sharedFmlonlyForge = { Project prj ->
 
                 property 'nativesDirectory', '{natives}'
 
+                args '-Djava.net.preferIPv6Addresses=system'
                 args '--launchTarget', "${launchPrefix}clientuserdev"
                 args '--version', 'MOD_DEV'
                 args '--assetIndex', '{asset_index}'
@@ -394,6 +395,7 @@ def sharedFmlonlyForge = { Project prj ->
                 environment 'MOD_CLASSES', '{source_roots}'
                 environment 'MCP_MAPPINGS', '{mcp_mappings}'
 
+                args '-Djava.net.preferIPv6Addresses=system'
                 args '--launchTarget', "${launchPrefix}serveruserdev"
             }
 
@@ -425,6 +427,8 @@ def sharedFmlonlyForge = { Project prj ->
         } else {
             run.client false
         }
+
+        run.jvmArgs '-Djava.net.preferIPv6Addresses=system'
 
         // SecureJarHandler bootstrap values.
         run.property 'ignoreList', prj.configurations.moduleonly.files.collect {it.name.replaceAll(/([-_]([.\d]*\d+)|\.jar$)/, '') }.join(',') + ",client-extra,fmlcore,javafmllanguage,mclanguage,${prj.name}-"
@@ -620,7 +624,8 @@ project(':fmlonly') {
                            '--fml.mcVersion', MC_VERSION,
                            '--fml.forgeGroup', project.group,
                            '--fml.mcpVersion', MCP_VERSION],
-                    jvm: ["-DignoreList=${fmlonly_client.properties.ignoreList},\${version_name}.jar",
+                    jvm: ['-Djava.net.preferIPv6Addresses=system',
+                          "-DignoreList=${fmlonly_client.properties.ignoreList},\${version_name}.jar",
                           "-DmergeModules=${fmlonly_client.properties.mergeModules}",
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{"\${library_directory}/${it.downloads.artifact.path}"}.join('${classpath_separator}'),
@@ -1165,7 +1170,8 @@ project(':forge') {
                            '--fml.mcVersion', MC_VERSION,
                            '--fml.forgeGroup', project.group,
                            '--fml.mcpVersion', MCP_VERSION],
-                    jvm: ["-DignoreList=${forge_client.properties.ignoreList},\${version_name}.jar",
+                    jvm: ['-Djava.net.preferIPv6Addresses=system',
+                          "-DignoreList=${forge_client.properties.ignoreList},\${version_name}.jar",
                           "-DmergeModules=${forge_client.properties.mergeModules}",
                           '-DlibraryDirectory=${library_directory}',
                           '-p', Util.getArtifacts(project, configurations.moduleonly, false).values().collect{'${library_directory}/' + it.downloads.artifact.path}.join('${classpath_separator}'),

--- a/patches/minecraft/net/minecraft/network/Connection.java.patch
+++ b/patches/minecraft/net/minecraft/network/Connection.java.patch
@@ -25,11 +25,9 @@
        }
  
        if (this.f_129468_.eventLoop().inEventLoop()) {
-@@ -277,7 +_,9 @@
-    }
+@@ -278,6 +_,7 @@
  
     public static Connection m_178300_(InetSocketAddress p_178301_, boolean p_178302_) {
-+      if (p_178301_.getAddress() instanceof java.net.Inet6Address) System.setProperty("java.net.preferIPv4Stack", "false");
        final Connection connection = new Connection(PacketFlow.CLIENTBOUND);
 +      connection.activationHandler = net.minecraftforge.network.NetworkHooks::registerClientLoginChannel;
        Class<? extends SocketChannel> oclass;

--- a/patches/minecraft/net/minecraft/server/network/ServerConnectionListener.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerConnectionListener.java.patch
@@ -15,14 +15,6 @@
     });
     final MinecraftServer f_9702_;
     public volatile boolean f_9700_;
-@@ -67,6 +_,7 @@
-    }
- 
-    public void m_9711_(@Nullable InetAddress p_9712_, int p_9713_) throws IOException {
-+      if (p_9712_ instanceof java.net.Inet6Address) System.setProperty("java.net.preferIPv4Stack", "false");
-       synchronized(this.f_9703_) {
-          Class<? extends ServerSocketChannel> oclass;
-          LazyLoadedValue<? extends EventLoopGroup> lazyloadedvalue;
 @@ -87,7 +_,7 @@
                 } catch (ChannelException channelexception) {
                 }

--- a/server_files/args.txt
+++ b/server_files/args.txt
@@ -2,6 +2,7 @@
 --add-modules @MODULES@
 --add-opens java.base/java.util.jar=cpw.mods.securejarhandler
 --add-exports java.base/sun.security.util=cpw.mods.securejarhandler
+-Djava.net.preferIPv6Addresses=system
 -DignoreList=@IGNORE_LIST@
 -DlibraryDirectory=libraries
 -DlegacyClassPath=@CLASS_PATH@


### PR DESCRIPTION
Forge has a couple of patches that presumably were made to help improve IPv6 support in dual-stack scenarios, however they unfortunately don't work.

This PR removes the two patches and replaces it with the `-Djava.net.preferIPv6Addresses=system` arg being added to the startup arguments, allowing the chosen IP address returned from a hostname to be determined by the underlying OS that the JVM is being ran on.

This fixes a couple of things:
1) If a server hostname resolves to both IPv4 and IPv6 addresses, the IPv6 ones are now considered by Forge clients whereas before they were always ignored (even if the IPv6 address works and has a lower ping due to potentially avoiding multiple CGNAT hops and old networking equipment)
2) If a client only has IPv6 connectivity and attempts to join a server that provides both IPv4 and IPv6 addresses, they are unable to connect as only the IPv4 address is used even it could connect fine with the supplied IPv6 address. This also applies if the server's IPv4 infrastructure is having trouble while IPv6 is fine

Note: when I say "server hostname", I mean an user-friendly address that resolves to IP addresses through a DNS. Such as `myserver.example.com` which might return an A record for an IPv4 address and a AAAA record for an IPv6 address.